### PR TITLE
Add mergemergeServiceFiles() to shadowJar task to allow HDFS paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - 1.0.0
 
+### Added
+- HDFS support for input and output. The URI should specify the schema (__hdfs__) and the host.
+
 ### Changed
 - Removed legacy tools
 - (Developer) Removed legacy IO system

--- a/build.gradle
+++ b/build.gradle
@@ -149,4 +149,5 @@ shadowJar {
     zip64 true
     classifier = null
     version = null
+    mergeServiceFiles()
 }


### PR DESCRIPTION
Without merging service files the provider for HDFS is not recognized and hdfs URIs are not supported.