### PR TITLE
Fix non-absolute path handling in ReadWriterFactory

### DIFF
--- a/src/main/java/org/magicdgs/readtools/utils/read/ReadWriterFactory.java
+++ b/src/main/java/org/magicdgs/readtools/utils/read/ReadWriterFactory.java
@@ -40,6 +40,7 @@ import org.broadinstitute.hellbender.utils.read.GATKReadWriter;
 import org.broadinstitute.hellbender.utils.read.SAMFileGATKReadWriter;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
@@ -214,8 +215,8 @@ public final class ReadWriterFactory {
             throw new RTUserExceptions.OutputFileExists(outputPath);
         }
         try {
-            Files.createDirectories(outputPath.getParent());
-        } catch (final Exception e) {
+            Files.createDirectories(outputPath.toAbsolutePath().getParent());
+        } catch (final IOException e) {
             throw new UserException.CouldNotCreateOutputFile(outputPath.toFile(), e.getMessage(),
                     e);
         }

--- a/src/test/java/org/magicdgs/readtools/utils/read/ReadWriterFactoryUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/ReadWriterFactoryUnitTest.java
@@ -93,4 +93,14 @@ public class ReadWriterFactoryUnitTest extends BaseTest {
                 .createWriter(existantFile.getAbsolutePath(), new SAMFileHeader(), true);
     }
 
+    @Test
+    public void testNonAbsolute() throws Exception {
+        final String nonAbsolute = "nonAbsolute.fq";
+        final File file = new File(nonAbsolute);
+        file.deleteOnExit();
+        Assert.assertFalse(file.exists(), "test implementation error");
+        new ReadWriterFactory()
+                .createWriter(nonAbsolute, null, true);
+        Assert.assertTrue(file.exists(), "file was not generated");
+    }
 }

--- a/src/test/java/org/magicdgs/readtools/utils/read/ReadWriterFactoryUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/ReadWriterFactoryUnitTest.java
@@ -37,7 +37,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.io.IOException;
 
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)

--- a/src/test/java/org/magicdgs/readtools/utils/read/ReadWriterFactoryUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/ReadWriterFactoryUnitTest.java
@@ -37,6 +37,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.IOException;
 
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
@@ -64,12 +65,12 @@ public class ReadWriterFactoryUnitTest extends BaseTest {
     public void testCorrectGATKWriter(final File outputFile,
             final Class<? extends GATKReadWriter> writerClass) {
         Assert.assertFalse(outputFile.exists());
+        outputFile.deleteOnExit();
         // TODO: add a FASTA file as reference to test CRAM writer creation
         Assert.assertEquals(new ReadWriterFactory()
                         .createWriter(outputFile.getAbsolutePath(), new SAMFileHeader(), true).getClass(),
                 writerClass);
         Assert.assertTrue(outputFile.exists());
-        outputFile.delete();
     }
 
     @Test(expectedExceptions = UserException.MissingReference.class)
@@ -102,5 +103,14 @@ public class ReadWriterFactoryUnitTest extends BaseTest {
         new ReadWriterFactory()
                 .createWriter(nonAbsolute, null, true);
         Assert.assertTrue(file.exists(), "file was not generated");
+    }
+
+    @Test(expectedExceptions = UserException.CouldNotCreateOutputFile.class)
+    public void testIOException() throws Exception {
+        final File fileAsDirectory = new File(testDir, "fileAsDirectory");
+        fileAsDirectory.deleteOnExit();
+        fileAsDirectory.createNewFile();
+        new ReadWriterFactory()
+                .createWriter(new File(fileAsDirectory, "example.fq").toString(), null, true);
     }
 }


### PR DESCRIPTION
Currently, if a non-absolute path is passed to `ReadWriterFactory`, the program blows up with a CouldNotCreateOutputFile due to a NPE. This is a bug that comes from checkOutputAndCreateDirs, which is fixed with:

- Handle correctly paths while creating intermediate folders (calling toAbsolutePath before getting the parent)
- Catching only IOException when creating the directories, to avoid overseen errors due to other causes.