### PR TITLE
Update htsjdk, gatk and barclay dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,8 @@ repositories {
     }
 }
 // versions for the dependencies
-final gatkVersion = '4.alpha.2-146-g2c85e82-SNAPSHOT' // TODO: we should use the master-SNAPSHOT one is done (gatk/issue#1995)
-final htsjdkVersion = '2.8.1-25-g8b9d5d5-SNAPSHOT' // TODO: bring back to the HTSJDK release
+final gatkVersion = '4.alpha.2-178-g5211285-SNAPSHOT' // TODO: we should use the master-SNAPSHOT one is done (gatk/issue#1995)
+final htsjdkVersion = '2.9.1-9-g6d22658-SNAPSHOT' // TODO: bring back to the HTSJDK release
 final testngVersion = "6.9.10"
 
 dependencies {
@@ -54,12 +54,16 @@ dependencies {
         // TODO: remove this line once the GKL is working
         // TODO: see https://github.com/broadinstitute/gatk/issues/2315
         exclude module: 'gkl'
+        // TODO: remove this line once the Barclay version of GATK includes the changes of the current Barclay snapshot
+        exclude module: 'barclay'
     }
     compile group: 'com.github.samtools', name: 'htsjdk', version: htsjdkVersion
     compile group: 'org.testng', name: 'testng', version: testngVersion
     // TODO: remove this line once the GKL is working
     // TODO: see https://github.com/broadinstitute/gatk/issues/2315
     compile "com.intel.gkl:gkl:0.2.0"
+    // TODO: remove this line once the Barclay version of GATK includes the changes of this snapshot
+    compile "org.broadinstitute:barclay:1.0.0-24-g87c3fa2-SNAPSHOT"
 }
 
 // for managing the wrapper task

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
@@ -175,11 +175,9 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
         return isAllowed;
     }
 
-    // TODO: this will be included in GATK after Barclay is updated, because now it have this method
-    // TODO: https://github.com/broadinstitute/barclay/blob/976fafea23216cf0577b8e3fe635b115c7975a76/src/main/java/org/broadinstitute/barclay/argparser/CommandLinePluginDescriptor.java#L164
-    // TODO: although there is a change in the signature, because I require that this is a list over T
-    // @Override
-    public List<ReadFilter> getDefaultInstances() {
+    // TODO: the signature should be change in Barclay: https://github.com/broadinstitute/barclay/pull/32
+    @Override
+    public List<Object> getDefaultInstances() {
         return (disableToolDefaultReadFilters)
                 ? new ArrayList<>()
                 : toolDefaultReadFilterNamesInOrder
@@ -220,6 +218,11 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
             }
         });
         return filters;
+    }
+
+    @Override
+    public Class<?> getClassForInstance(final String pluginName) {
+        return readFilters.get(pluginName).getClass();
     }
 
     // Return the allowable values for readFilterNames/disableReadFilter

--- a/src/main/java/org/magicdgs/readtools/cmd/plugin/TrimmerPluginDescriptor.java
+++ b/src/main/java/org/magicdgs/readtools/cmd/plugin/TrimmerPluginDescriptor.java
@@ -330,9 +330,9 @@ public final class TrimmerPluginDescriptor extends CommandLinePluginDescriptor<T
      * Note: only the enabled trimmers will be returned.
      */
     //
-    // TODO: to override, requires update of Barclay
-    // @Override TODO: the signature of the overridden method in Barclay is still Object
-    public List<TrimmingFunction> getDefaultInstances() {
+    // TODO: the signature should be change in Barclay: https://github.com/broadinstitute/barclay/pull/32
+    @Override
+    public List<Object> getDefaultInstances() {
         return (disableAllDefaultTrimmers)
                 ? Collections.emptyList()
                 : toolDefaultTrimmerNamesInOrder.stream()
@@ -376,5 +376,10 @@ public final class TrimmerPluginDescriptor extends CommandLinePluginDescriptor<T
                 })
                 .filter(tf -> tf != null)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public Class<?> getClassForInstance(String pluginName) {
+        return trimmers.get(pluginName).getClass();
     }
 }

--- a/src/main/java/org/magicdgs/readtools/tools/trimming/TrimAndFilterPipeline.java
+++ b/src/main/java/org/magicdgs/readtools/tools/trimming/TrimAndFilterPipeline.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.BiPredicate;
+import java.util.stream.Collectors;
 
 /**
  * Implements a pipeline for trimming in place (through {@link TrimmingFunction}) and filter
@@ -275,12 +276,14 @@ public class TrimAndFilterPipeline extends ReadFilter {
             final GATKReadFilterPluginDescriptor filterPlugin) {
 
         // add the default and afterwards the ones provided by the user
-        final List<TrimmingFunction> trimmers =
-                new ArrayList<>(trimmingPlugin.getDefaultInstances());
-        trimmers.addAll(trimmingPlugin.getAllInstances());
+        final List<TrimmingFunction> trimmers = trimmingPlugin.getDefaultInstances().stream()
+                .map(tf -> (TrimmingFunction) tf) // TODO: this is necessary because it is now a set of filters
+                .collect(Collectors.toList());
 
         // the same for filters
-        final List<ReadFilter> filters = new ArrayList<>(filterPlugin.getDefaultInstances());
+        final List<ReadFilter> filters = filterPlugin.getDefaultInstances().stream()
+                .map(rf -> (ReadFilter) rf) // TODO: this is necessary because it is now a set of filters
+                .collect(Collectors.toList());
         filters.addAll(filterPlugin.getAllInstances());
 
         // throw if not pipeline is specified

--- a/src/main/java/org/magicdgs/readtools/tools/trimming/TrimReads.java
+++ b/src/main/java/org/magicdgs/readtools/tools/trimming/TrimReads.java
@@ -43,6 +43,7 @@ import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.Histogram;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
+import org.broadinstitute.barclay.argparser.CommandLineParser;
 import org.broadinstitute.barclay.argparser.CommandLinePluginDescriptor;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.GATKPlugin.GATKReadFilterPluginDescriptor;
@@ -90,7 +91,7 @@ public final class TrimReads extends ReadToolsWalker {
     // for discard the ambiguous sequences (--discard-internal-N in previous tool)
     // use --readFilter AmbiguousBaseReadFilter --ambigFilterFrac 0
     @Override
-    protected List<? extends CommandLinePluginDescriptor<?>> getPluginDescriptors() {
+    public List<? extends CommandLinePluginDescriptor<?>> getPluginDescriptors() {
         return Arrays.asList(
                 new TrimmerPluginDescriptor(
                         Arrays.asList(new TrailingNtrimmer(), new MottQualityTrimmer())),
@@ -127,6 +128,7 @@ public final class TrimReads extends ReadToolsWalker {
         }
 
         // initialize the pipeline with the plugin descriptors
+        final CommandLineParser commandLineParser = getCommandLineParser();
         pipeline = TrimAndFilterPipeline.fromPluginDescriptors(
                 commandLineParser.getPluginDescriptor(TrimmerPluginDescriptor.class),
                 commandLineParser.getPluginDescriptor(GATKReadFilterPluginDescriptor.class));

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptorUnitTest.java
@@ -28,7 +28,7 @@ public class GATKReadFilterPluginDescriptorUnitTest {
             this.defaultFilters = defaultFilters;
         }
 
-        protected List<? extends CommandLinePluginDescriptor<?>> getPluginDescriptors() {
+        public List<? extends CommandLinePluginDescriptor<?>> getPluginDescriptors() {
             return Collections.singletonList(new GATKReadFilterPluginDescriptor(defaultFilters));
         }
 

--- a/src/test/java/org/magicdgs/readtools/cmd/plugin/TrimmerPluginDescriptorUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/plugin/TrimmerPluginDescriptorUnitTest.java
@@ -72,7 +72,7 @@ public class TrimmerPluginDescriptorUnitTest extends BaseTest {
         Assert.assertTrue(pluginDescriptor.getAllInstances().isEmpty());
 
         // test that default instances are not
-        final List<TrimmingFunction> defaultInsances = pluginDescriptor.getDefaultInstances();
+        final List<Object> defaultInsances = pluginDescriptor.getDefaultInstances();
         Assert.assertEquals(defaultInsances.size(), 1);
         Assert.assertSame(defaultInsances.get(0), anonymous);
     }
@@ -220,7 +220,7 @@ public class TrimmerPluginDescriptorUnitTest extends BaseTest {
 
         // test the defaults classes
         Assert.assertEquals(
-                tpd.getDefaultInstances().stream().map(TrimmingFunction::getClass)
+                tpd.getDefaultInstances().stream().map(Object::getClass)
                         .collect(Collectors.toList()), expectedDefaults,
                 "defaults are wrong: " + tpd.getDefaultInstances());
 


### PR DESCRIPTION
- Use the latest master of GATK
- Use the latest HTSJDK release (2.9.1)
- Use Barclay snapshot with a bug fix important for compilation
- Fix changes in Barclay plugin interface