### PR TITLE
Add tests for GATK read plugin compatibility

### DIFF
--- a/src/test/java/org/magicdgs/readtools/tools/trimming/TrimAndFilterPipelineUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/trimming/TrimAndFilterPipelineUnitTest.java
@@ -558,7 +558,6 @@ public class TrimAndFilterPipelineUnitTest extends BaseTest {
         Assert.assertEquals(pipeline.getTrimmingStats().size(), defaultTrimmers.size());
         // and the filters
         Assert.assertEquals(pipeline.getFilterStats().size(), expectedFilters);
-
     }
 
     @Test


### PR DESCRIPTION
Currently the read plugin compatibility with GATK is broken, and that's
why we have a hacked class for it. This commit adds more tests to check
the compatibility, and be sure that there is no regression if we remove
the hack when GATK includes the fixes.