### PR TITLE
Add travis sanity check for command line parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ install:
 
 script:
     - java -jar ./build/libs/ReadTools.jar --version
+    # running also the version of a tool to test CMD parsing
+    - java -jar ./build/libs/ReadTools.jar StandardizeReads --version
     - ./gradlew jacocoTestReport
 
 after_success:


### PR DESCRIPTION
This is a new travis sanity check for #146 not happening again.