### PR TITLE
Add argument collection for fixing barcodes in tools

### DIFF
--- a/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/FixBarcodeAbstractArgumentCollection.java
+++ b/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/FixBarcodeAbstractArgumentCollection.java
@@ -1,0 +1,255 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.magicdgs.readtools.cmd.argumentcollections;
+
+import org.magicdgs.readtools.cmd.RTStandardArguments;
+import org.magicdgs.readtools.utils.read.RTReadUtils;
+import org.magicdgs.readtools.utils.read.transformer.barcodes.FixRawBarcodeTagsReadTransformer;
+import org.magicdgs.readtools.utils.read.transformer.barcodes.FixReadNameBarcodesReadTransformer;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.CommandLineException;
+import org.broadinstitute.hellbender.transformers.ReadTransformer;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.ReadUtils;
+import scala.Tuple2;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Abstract rgument collection for fixing barcodes that are encoded in different places than the
+ * {@link RTReadUtils#RAW_BARCODE_TAG} tag.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public abstract class FixBarcodeAbstractArgumentCollection implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Argument(fullName = RTStandardArguments.RAW_BARCODE_SEQUENCE_TAG_NAME, shortName = RTStandardArguments.RAW_BARCODE_SEQUENCE_TAG_NAME, doc = "Include the barcodes encoded in this tag(s) in the read name. Note: this is not necessary for input FASTQ files.", optional = true,
+            mutex = {RTStandardArguments.USER_READ_NAME_BARCODE_NAME})
+    public List<String> rawBarcodeTags = new ArrayList<>(RTReadUtils.RAW_BARCODE_TAG_LIST);
+
+    @Argument(fullName = RTStandardArguments.USER_READ_NAME_BARCODE_NAME, shortName = RTStandardArguments.USER_READ_NAME_BARCODE_NAME, doc = "Use the barcode encoded in SAM/BAM/CRAM read names. Note: this is not necessary for input FASTQ files.", optional = true,
+            mutex = {RTStandardArguments.RAW_BARCODE_SEQUENCE_TAG_NAME})
+    public boolean useReadNameBarcode = false;
+
+    // cached transformer, initialized if needed
+    private ReadTransformer transformer = null;
+
+    /** Logger for the class. */
+    protected final Logger logger =
+            LogManager.getLogger(FixBarcodeAbstractArgumentCollection.class);
+
+    /** Gets the raw barcode quality tags if they are provided by the command line. */
+    protected abstract List<String> getRawBarcodeQualityTags();
+
+    /**
+     * Fix the single-end barcodes' tags using the provided arguments.
+     *
+     * @param singleEnd single-end read.
+     *
+     * @return the same read modified in-place.
+     */
+    public GATKRead fixBarcodeTags(final GATKRead singleEnd) {
+        // this rely on in place transformation
+        getFixBarcodeReadTransformer().apply(singleEnd);
+        return singleEnd;
+    }
+
+    /**
+     * Fix the pair-end barcodes' tags using the provided arguments.
+     *
+     * @param reads pair-end reads.
+     *
+     * @return the same tuple, with the reads modified in-place.
+     */
+    public Tuple2<GATKRead, GATKRead> fixBarcodeTags(final Tuple2<GATKRead, GATKRead> reads) {
+        // this rely on in place transformation
+        getFixBarcodeReadTransformer().apply(reads._1);
+        getFixBarcodeReadTransformer().apply(reads._2);
+        fixBarcodeForPair(reads._1, reads._2);
+        return reads;
+    }
+
+    /**
+     * Fix the barcodes for the pair. Default implementation only fix the
+     * {@link RTReadUtils#RAW_BARCODE_TAG} tag.
+     */
+    protected void fixBarcodeForPair(final GATKRead read1, final GATKRead read2) {
+        RTReadUtils.fixPairTag(RTReadUtils.RAW_BARCODE_TAG, read1, read2);
+    }
+
+    /**
+     * Validate the arguments after parsing. Default implementation check for repeated barcode
+     * tags.
+     */
+    public void validateArguments() {
+        // non-duplicated tags
+        final Set<String> duplicated = Utils.getDuplicatedItems(rawBarcodeTags);
+        if (!duplicated.isEmpty()) {
+            throw new CommandLineException.BadArgumentValue(
+                    RTStandardArguments.RAW_BARCODE_SEQUENCE_TAG_NAME,
+                    "contain duplicated tags: " + duplicated);
+        }
+
+        // valid tag names
+        rawBarcodeTags.forEach(rbt -> validateTagArgument(rbt,
+                RTStandardArguments.RAW_BARCODE_SEQUENCE_TAG_NAME));
+    }
+
+    /** Gets a ReadTransformer to fix the barcodes. */
+    protected final ReadTransformer getFixBarcodeReadTransformer() {
+        if (transformer == null) {
+            // if it is using the read names, apply the simplest fix
+            if (useReadNameBarcode) {
+                logger.debug("Using barcodes from read names");
+                transformer = new FixReadNameBarcodesReadTransformer();
+            } else if (!rawBarcodeTags.isEmpty()) {
+
+                // if there are barcode tags, try to get qualities too
+                final List<String> rawBarcodeQualsTags = getRawBarcodeQualityTags();
+
+                // if no quality tags, not fixing; otherwise fix and log
+                if (rawBarcodeQualsTags.isEmpty()) {
+                    logger.warn("Quality tags are not updated.");
+                    if (!rawBarcodeTags.equals(RTReadUtils.RAW_BARCODE_TAG_LIST)) {
+                        logger.debug("Using barcode tags: {}", () -> rawBarcodeTags);
+                        transformer = new FixRawBarcodeTagsReadTransformer(rawBarcodeTags);
+                    }
+                } else {
+                    logger.debug("Using barcode tags: {}", () -> rawBarcodeTags);
+                    logger.debug("Using quality tags: {}", () -> rawBarcodeQualsTags);
+                    transformer = new FixRawBarcodeTagsReadTransformer(rawBarcodeTags,
+                            rawBarcodeQualsTags);
+                }
+            }
+            if (transformer == null) {
+                logger.debug("Not using barcode tags: {}", () -> rawBarcodeTags);
+                transformer = ReadTransformer.identity();
+            }
+        }
+        return transformer;
+    }
+
+    /**
+     * Gets an argument collection implementation.
+     *
+     * @param fixQualitiesArgument if {@code true}, provides an argument to fix the qualities.
+     */
+    public static final FixBarcodeAbstractArgumentCollection getArgumentCollection(
+            final boolean fixQualitiesArgument) {
+        return (fixQualitiesArgument)
+                ? new FixBarcodeWithQualitiesArgumentCollection()
+                : new FixSimpleBarcodeArgumentCollection();
+    }
+
+
+    /** Implementation without barcode qualities. */
+    private static final class FixSimpleBarcodeArgumentCollection
+            extends FixBarcodeAbstractArgumentCollection {
+
+        @Override
+        protected List<String> getRawBarcodeQualityTags() {
+            return Collections.emptyList();
+        }
+    }
+
+    /** Implementation with barocde qualities */
+    private static final class FixBarcodeWithQualitiesArgumentCollection
+            extends FixBarcodeAbstractArgumentCollection {
+
+        @Argument(fullName = RTStandardArguments.RAW_BARCODE_QUALITIES_TAG_NAME, shortName = RTStandardArguments.RAW_BARCODE_QUALITIES_TAG_NAME, doc =
+                "Use the qualities encoded in this tag(s) as raw barcode qualities. Requires --"
+                        + RTStandardArguments.RAW_BARCODE_SEQUENCE_TAG_NAME
+                        + ". WARNING: this tag(s) will be removed.", optional = true,
+                mutex = {RTStandardArguments.USER_READ_NAME_BARCODE_NAME})
+        public List<String> rawBarcodeQualsTags = new ArrayList<>();
+
+        @Override
+        protected List<String> getRawBarcodeQualityTags() {
+            return rawBarcodeQualsTags;
+        }
+
+        /** Overrides to fix also the quality tag. */
+        @Override
+        public void fixBarcodeForPair(final GATKRead read1, final GATKRead read2) {
+            super.fixBarcodeForPair(read1, read2);
+            RTReadUtils.fixPairTag(RTReadUtils.RAW_BARCODE_QUALITY_TAG, read1, read2);
+        }
+
+        /** Calls supper and afterwards check barcode tags. */
+        @Override
+        public void validateArguments() {
+            super.validateArguments();
+            // non-duplicated tags
+            final Set<String> duplicated = Utils.getDuplicatedItems(rawBarcodeQualsTags);
+            if (!duplicated.isEmpty()) {
+                throw new CommandLineException.BadArgumentValue(
+                        RTStandardArguments.RAW_BARCODE_QUALITIES_TAG_NAME,
+                        "contain duplicated tags: " + duplicated);
+            }
+
+            // valid quality tag names
+            rawBarcodeQualsTags.forEach(rbt -> validateTagArgument(rbt,
+                    RTStandardArguments.RAW_BARCODE_QUALITIES_TAG_NAME));
+
+            // if quals are used, requires at least a raw barcode tag
+            if (rawBarcodeTags.isEmpty() && !rawBarcodeQualsTags.isEmpty()) {
+                throw new CommandLineException.MissingArgument(
+                        RTStandardArguments.RAW_BARCODE_SEQUENCE_TAG_NAME,
+                        "required if --" + RTStandardArguments.RAW_BARCODE_QUALITIES_TAG_NAME
+                                + "is specified.");
+            }
+
+            // the same number of barcode/quals tags
+            // TODO 20-03-2017: maybe we should allow different number of tags
+            // TODO           : this will require a new implementation, but we do not see any use-case yet
+            if (!rawBarcodeQualsTags.isEmpty()
+                    && rawBarcodeTags.size() != rawBarcodeQualsTags.size()) {
+                throw new CommandLineException.BadArgumentValue(
+                        "--" + RTStandardArguments.RAW_BARCODE_SEQUENCE_TAG_NAME
+                                + " and --" + RTStandardArguments.RAW_BARCODE_QUALITIES_TAG_NAME
+                                + " should be provided the same number of times.");
+            }
+        }
+    }
+
+    // helper method to thrown CommandLineException if the tag is not a legal one based on the SAM specs
+    private static void validateTagArgument(final String tag, final String argName) {
+        try {
+            ReadUtils.assertAttributeNameIsLegal(tag);
+        } catch (IllegalArgumentException e) {
+            throw new CommandLineException.BadArgumentValue(argName, e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode.java
+++ b/src/main/java/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode.java
@@ -139,6 +139,7 @@ public final class AssignReadGroupByBarcode extends ReadToolsWalker {
      */
     @Override
     protected void apply(final GATKRead read) {
+        logger.debug("Read = {}", () -> read);
         // assumes that the transformed read is modified in place
         decoder.assignReadGroupByBarcode(fixBarcodeArguments.fixBarcodeTags(read));
         writeRead(read);

--- a/src/main/java/org/magicdgs/readtools/utils/read/RTReadUtils.java
+++ b/src/main/java/org/magicdgs/readtools/utils/read/RTReadUtils.java
@@ -52,9 +52,16 @@ public class RTReadUtils {
     /** Zero quality character. */
     public final static char ZERO_QUALITY_CHAR = '!';
 
-    /** Default raw barcode tag (as defined in the SAM specs). Corresponds to {@link SAMTag#BC}. */
+    /**
+     * Default raw barcode tag (as defined in the SAM specs).
+     * Corresponds to {@link SAMTag#BC}.
+     */
     public final static String RAW_BARCODE_TAG = SAMTag.BC.name();
 
+    /**
+     * Default raw barcode tag for qualities (as defined in the SAM specs).
+     * Corresponds to {@link SAMTag#QT}.
+     */
     public final static String RAW_BARCODE_QUALITY_TAG = SAMTag.QT.name();
 
     /** Default raw barcode tag ({@link #RAW_BARCODE_TAG}) as a singleton list. */

--- a/src/main/java/org/magicdgs/readtools/utils/read/RTReadUtils.java
+++ b/src/main/java/org/magicdgs/readtools/utils/read/RTReadUtils.java
@@ -52,9 +52,14 @@ public class RTReadUtils {
     /** Zero quality character. */
     public final static char ZERO_QUALITY_CHAR = '!';
 
-    // this is for avoid re-instantation
-    private final static List<String> RAW_BARCODE_TAGS =
-            Collections.singletonList(SAMTag.BC.name());
+    /** Default raw barcode tag (as defined in the SAM specs). Corresponds to {@link SAMTag#BC}. */
+    public final static String RAW_BARCODE_TAG = SAMTag.BC.name();
+
+    public final static String RAW_BARCODE_QUALITY_TAG = SAMTag.QT.name();
+
+    /** Default raw barcode tag ({@link #RAW_BARCODE_TAG}) as a singleton list. */
+    public final static List<String> RAW_BARCODE_TAG_LIST =
+            Collections.singletonList(RAW_BARCODE_TAG);
 
     /**
      * Extract and remove the barcode from the read name, splitting the barcodes in the read name
@@ -166,18 +171,18 @@ public class RTReadUtils {
     }
 
     /**
-     * Returns the raw barcodes from the {@link SAMTag#BC} tag.
+     * Returns the raw barcodes from the {@link #RAW_BARCODE_TAG} tag.
      *
      * @param read the read to extract the barcodes from.
      *
      * @return the barcodes in the provided tags (in order) if any; empty array otherwise.
      */
     public static String[] getRawBarcodes(final GATKRead read) {
-        return getBarcodesFromTags(read, RAW_BARCODE_TAGS);
+        return getBarcodesFromTags(read, RAW_BARCODE_TAG_LIST);
     }
 
     /**
-     * Sets the {@link SAMTag#BC} tag for a read, joining the barcodes with {@link
+     * Sets the {@link #RAW_BARCODE_TAG} tag for a read, joining the barcodes with {@link
      * RTDefaults#BARCODE_INDEX_DELIMITER}.
      *
      * @param read     the read to update with the barcodes.
@@ -188,15 +193,15 @@ public class RTReadUtils {
         Utils.nonNull(barcodes, "null barcodes");
         // only update if there are barcodes
         if (barcodes.length != 0) {
-            read.setAttribute(SAMTag.BC.name(),
+            read.setAttribute(RAW_BARCODE_TAG,
                     String.join(RTDefaults.BARCODE_INDEX_DELIMITER, barcodes));
         }
     }
 
 
     /**
-     * Sets the {@link SAMTag#BC} and {@link SAMTag#QT} tags for a read, joining the
-     * barcodes/qualities with {@link RTDefaults#BARCODE_INDEX_DELIMITER}.
+     * Sets the {@link #RAW_BARCODE_TAG} and {@link #RAW_BARCODE_QUALITY_TAG} tags for a read,
+     * joining the barcodes/qualities with {@link RTDefaults#BARCODE_INDEX_DELIMITER}.
      *
      * Note: barcodes and qualities should have the same length.
      *
@@ -217,11 +222,11 @@ public class RTReadUtils {
             final String qualityString = String.join(RTDefaults.BARCODE_INDEX_DELIMITER, qualities);
             // perform extra validation of lengths
             if (barcodeString.length() != qualityString.length()) {
-                throwExceptionForDifferentBarcodeQualityLenghts(SAMTag.BC.name(), barcodeString,
-                        SAMTag.QT.name(), qualityString);
+                throwExceptionForDifferentBarcodeQualityLenghts(RAW_BARCODE_TAG, barcodeString,
+                        RAW_BARCODE_QUALITY_TAG, qualityString);
             }
-            read.setAttribute(SAMTag.BC.name(), barcodeString);
-            read.setAttribute(SAMTag.QT.name(), qualityString);
+            read.setAttribute(RAW_BARCODE_TAG, barcodeString);
+            read.setAttribute(RAW_BARCODE_QUALITY_TAG, qualityString);
         }
     }
 

--- a/src/main/java/org/magicdgs/readtools/utils/read/transformer/barcodes/FixRawBarcodeTagsReadTransformer.java
+++ b/src/main/java/org/magicdgs/readtools/utils/read/transformer/barcodes/FixRawBarcodeTagsReadTransformer.java
@@ -35,15 +35,15 @@ import java.util.List;
 import java.util.function.Consumer;
 
 /**
- * Use different tags to encode and update the {@link htsjdk.samtools.SAMTag#BC} tag (and
- * {@link htsjdk.samtools.SAMTag#QT} if requested). In addition, used tags are discarded because
- * they are already encoded in the raw BC/QT tags and they are not longer needed.
+ * Use different tags to encode and update the {@link RTReadUtils#RAW_BARCODE_TAG} tag
+ * (and {@link RTReadUtils#RAW_BARCODE_QUALITY_TAG} if requested). In addition, used tags are
+ * discarded because they are already encoded in the raw raw tags and they are not longer needed.
  *
  * This may be useful only in several cases:
  *
  * - When output a FASTQ file, some other tags want to be used into the read name.
- * - For old BAM data where barcodes where stored in the deprecated tag {@link
- * htsjdk.samtools.SAMTag#RT}.
+ * - For old BAM data where barcodes where stored in the deprecated tag
+ * {@link htsjdk.samtools.SAMTag#RT}.
  * - When other tools were used to encode a read. For example,
  * <a href=http://gq1.github.io/illumina2bam/index.html>illumina2bam</a> uses BC/QT to encode the
  * first index/quality, and B2/Q2 to encode the second. By providing to this transformer a list

--- a/src/main/java/org/magicdgs/readtools/utils/read/transformer/barcodes/FixReadNameBarcodesReadTransformer.java
+++ b/src/main/java/org/magicdgs/readtools/utils/read/transformer/barcodes/FixReadNameBarcodesReadTransformer.java
@@ -31,7 +31,7 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 /**
  * Fix barcodes stored in the read read name (Illumina formatted) putting them into the
- * default barcode tag ({@link htsjdk.samtools.SAMTag#BC}), and removing them from the name.
+ * default barcode tag ({@link RTReadUtils#RAW_BARCODE_TAG}), and removing them from the name.
  *
  * This may be useful when reading a BAM file mapped from a FASTQ file where the barcodes are keep
  * in the read name. For example, <a href=http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0072614>Distmap</a>

--- a/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/FixBarcodeAbstractArgumentCollectionTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/FixBarcodeAbstractArgumentCollectionTest.java
@@ -110,7 +110,8 @@ public class FixBarcodeAbstractArgumentCollectionTest extends BaseTest {
         data.add(new Object[] {
                 new ArgumentsBuilder()
                         .addBooleanArgument("barcodeInReadName", true)
-                        .addArgument("rawBarcodeQualityTag", "Q2")});
+                        .addArgument("rawBarcodeQualityTag", "Q2"),
+                true});
 
         // repeat quality tag
         data.add(new Object[] {

--- a/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/FixBarcodeAbstractArgumentCollectionTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/FixBarcodeAbstractArgumentCollectionTest.java
@@ -39,6 +39,11 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
@@ -69,109 +74,83 @@ public class FixBarcodeAbstractArgumentCollectionTest extends BaseTest {
     }
 
     @DataProvider(name = "badArgs")
-    public Object[][] getBadArguments() {
-        return new Object[][] {
-                // Without fixing quality
-                // incompatible arguments
-                {new ArgumentsBuilder()
-                        .addBooleanArgument("barcodeInReadName", true)
-                        .addArgument("rawBarcodeSequenceTags", "B1"),
-                        false},
-                // repeating barcodes should fail
-                {new ArgumentsBuilder()
-                        .addArgument("rawBarcodeSequenceTags", "B1")
-                        .addArgument("rawBarcodeSequenceTags", "B1"),
-                        false},
-                // invalid tag names
-                {new ArgumentsBuilder()
-                        .addArgument("rawBarcodeSequenceTags", "1A"),
-                        false},
-                {new ArgumentsBuilder()
-                        .addArgument("rawBarcodeSequenceTags", "B1A"),
-                        false},
-                {new ArgumentsBuilder()
-                        .addArgument("rawBarcodeSequenceTags", "A+"),
-                        false},
-                {new ArgumentsBuilder()
-                        .addArgument("rawBarcodeSequenceTags", "+A"),
-                        false},
+    public Iterator<Object[]> getBadArguments() {
+        final List<Object[]> data = new ArrayList<>(20);
 
-                // With fixing quality bad arguments
-                // incompatible arguments (in read name and sequence tag)
-                {new ArgumentsBuilder()
+        final List<String> invalidTagNames = Arrays.asList("1A", "B1A", "A+", "+A");
+
+        // common failing arguments
+        for (boolean fixQuals : new boolean[] {true, false}) {
+            // incompatible arguments (read name and barcode sequence)
+            data.add(new Object[] {
+                    new ArgumentsBuilder()
+                            .addBooleanArgument("barcodeInReadName", true)
+                            .addArgument("rawBarcodeSequenceTags", "B1"),
+                    fixQuals});
+            // repeat barcode sequences
+            data.add(new Object[] {
+                    new ArgumentsBuilder()
+                            .addArgument("rawBarcodeSequenceTags", "B1")
+                            .addArgument("rawBarcodeSequenceTags", "B1"),
+                    fixQuals});
+            // invalid tag names in barcode sequence
+            invalidTagNames.forEach(tag -> data.add(new Object[] {
+                    new ArgumentsBuilder()
+                            .addArgument("rawBarcodeSequenceTags", tag),
+                    fixQuals}));
+        }
+
+        // invalid tag names in quality tag
+        invalidTagNames.forEach(tag -> data.add(new Object[] {
+                new ArgumentsBuilder()
+                        .addArgument("rawBarcodeQualityTag", tag),
+                true}));
+
+        // incompatible arguments (read name and quality tag)
+        data.add(new Object[] {
+                new ArgumentsBuilder()
                         .addBooleanArgument("barcodeInReadName", true)
-                        .addArgument("rawBarcodeSequenceTags", "B1"),
-                        true},
-                // incompatible arguments (in read name and quality tag)
-                {new ArgumentsBuilder()
-                        .addBooleanArgument("barcodeInReadName", true)
-                        .addArgument("rawBarcodeQualityTag", "Q2"),
-                        true},
-                // repeating barcodes should fail
-                {new ArgumentsBuilder()
-                        .addArgument("rawBarcodeSequenceTags", "B1")
-                        .addArgument("rawBarcodeSequenceTags", "B1"),
-                        true},
-                // repeating qualities should fail
-                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeQualityTag", "Q2")});
+
+        // repeat quality tag
+        data.add(new Object[] {
+                new ArgumentsBuilder()
                         .addArgument("rawBarcodeSequenceTags", "B1")
                         .addArgument("rawBarcodeSequenceTags", "B2")
                         .addArgument("rawBarcodeQualityTag", "Q1")
                         .addArgument("rawBarcodeQualityTag", "Q1"),
-                        true},
-                // only quality
-                {new ArgumentsBuilder()
+                true});
+
+        // only quality (setting to null barcode sequence tags
+        data.add(new Object[] {
+                new ArgumentsBuilder()
                         .addArgument("rawBarcodeSequenceTags", "null")
                         .addArgument("rawBarcodeQualityTag", "Q2"),
-                        true},
-                // two quality tags and only one barcode quality (default)
-                {new ArgumentsBuilder()
+                true});
+
+        // different length of sequence/quality tag (default sequence)
+        data.add(new Object[] {
+                new ArgumentsBuilder()
                         .addArgument("rawBarcodeQualityTag", "Q1")
                         .addArgument("rawBarcodeQualityTag", "Q2"),
-                        true},
-                // two quality tags and only one barcode quality (overridden)
-                {new ArgumentsBuilder()
+                true});
+
+        // different length of sequence/quality tag (overridden sequence)
+        data.add(new Object[] {
+                new ArgumentsBuilder()
                         .addArgument("rawBarcodeQualityTag", "Q1")
                         .addArgument("rawBarcodeQualityTag", "Q2")
                         .addArgument("rawBarcodeSequenceTags", "B1"),
-                        true},
-                // two barcode tags and only one quality (overridden)
-                {new ArgumentsBuilder()
+                true});
+        // and in the other way around
+        data.add(new Object[] {
+                new ArgumentsBuilder()
                         .addArgument("rawBarcodeSequenceTags", "B1")
                         .addArgument("rawBarcodeSequenceTags", "B2")
                         .addArgument("rawBarcodeQualityTag", "Q1"),
-                        true},
-                // incompatible arguments
-                {new ArgumentsBuilder()
-                        .addBooleanArgument("barcodeInReadName", true)
-                        .addArgument("rawBarcodeSequenceTags", "B1"),
-                        true},
-                // invalid qual tag names
-                {new ArgumentsBuilder()
-                        .addArgument("rawBarcodeQualityTag", "1A"),
-                        true},
-                {new ArgumentsBuilder()
-                        .addArgument("rawBarcodeQualityTag", "A1A"),
-                        true},
-                {new ArgumentsBuilder()
-                        .addArgument("rawBarcodeQualityTag", "A+"),
-                        true},
-                {new ArgumentsBuilder()
-                        .addArgument("rawBarcodeQualityTag", "+A"),
-                        true},
-                {new ArgumentsBuilder()
-                        .addArgument("rawBarcodeQualityTag", "1A"),
-                        true},
-                {new ArgumentsBuilder()
-                        .addArgument("rawBarcodeQualityTag", "A1A"),
-                        true},
-                {new ArgumentsBuilder()
-                        .addArgument("rawBarcodeQualityTag", "A+"),
-                        true},
-                {new ArgumentsBuilder()
-                        .addArgument("rawBarcodeQualityTag", "+A"),
-                        true}
-        };
+                true});
+
+        return data.iterator();
     }
 
     @Test(dataProvider = "badArgs", expectedExceptions = CommandLineException.class)

--- a/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/FixBarcodeAbstractArgumentCollectionTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/FixBarcodeAbstractArgumentCollectionTest.java
@@ -1,0 +1,251 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.magicdgs.readtools.cmd.argumentcollections;
+
+import org.magicdgs.readtools.utils.read.transformer.barcodes.FixRawBarcodeTagsReadTransformer;
+import org.magicdgs.readtools.utils.read.transformer.barcodes.FixReadNameBarcodesReadTransformer;
+import org.magicdgs.readtools.utils.tests.BaseTest;
+
+import org.broadinstitute.barclay.argparser.ArgumentCollection;
+import org.broadinstitute.barclay.argparser.CommandLineException;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
+import org.broadinstitute.hellbender.cmdline.TestProgramGroup;
+import org.broadinstitute.hellbender.transformers.ReadTransformer;
+import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class FixBarcodeAbstractArgumentCollectionTest extends BaseTest {
+
+    @CommandLineProgramProperties(
+            oneLineSummary = "Fix barcodes CLP test",
+            summary = "Fix barcodes CLP test",
+            programGroup = TestProgramGroup.class)
+    private static class FixBarcodesCLP extends CommandLineProgram {
+        @ArgumentCollection
+        public FixBarcodeAbstractArgumentCollection args;
+
+        public FixBarcodesCLP(final boolean fixQuals) {
+            this.args = FixBarcodeAbstractArgumentCollection.getArgumentCollection(fixQuals);
+        }
+
+        @Override
+        public String[] customCommandLineValidation() {
+            args.validateArguments();
+            return null;
+        }
+
+        @Override
+        protected Object doWork() {
+            return args.getFixBarcodeReadTransformer().getClass();
+        }
+    }
+
+    @DataProvider(name = "badArgs")
+    public Object[][] getBadArguments() {
+        return new Object[][] {
+                // Without fixing quality
+                // incompatible arguments
+                {new ArgumentsBuilder()
+                        .addBooleanArgument("barcodeInReadName", true)
+                        .addArgument("rawBarcodeSequenceTags", "B1"),
+                        false},
+                // repeating barcodes should fail
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeSequenceTags", "B1")
+                        .addArgument("rawBarcodeSequenceTags", "B1"),
+                        false},
+                // invalid tag names
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeSequenceTags", "1A"),
+                        false},
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeSequenceTags", "B1A"),
+                        false},
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeSequenceTags", "A+"),
+                        false},
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeSequenceTags", "+A"),
+                        false},
+
+                // With fixing quality bad arguments
+                // incompatible arguments (in read name and sequence tag)
+                {new ArgumentsBuilder()
+                        .addBooleanArgument("barcodeInReadName", true)
+                        .addArgument("rawBarcodeSequenceTags", "B1"),
+                        true},
+                // incompatible arguments (in read name and quality tag)
+                {new ArgumentsBuilder()
+                        .addBooleanArgument("barcodeInReadName", true)
+                        .addArgument("rawBarcodeQualityTag", "Q2"),
+                        true},
+                // repeating barcodes should fail
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeSequenceTags", "B1")
+                        .addArgument("rawBarcodeSequenceTags", "B1"),
+                        true},
+                // repeating qualities should fail
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeSequenceTags", "B1")
+                        .addArgument("rawBarcodeSequenceTags", "B2")
+                        .addArgument("rawBarcodeQualityTag", "Q1")
+                        .addArgument("rawBarcodeQualityTag", "Q1"),
+                        true},
+                // only quality
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeSequenceTags", "null")
+                        .addArgument("rawBarcodeQualityTag", "Q2"),
+                        true},
+                // two quality tags and only one barcode quality (default)
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeQualityTag", "Q1")
+                        .addArgument("rawBarcodeQualityTag", "Q2"),
+                        true},
+                // two quality tags and only one barcode quality (overridden)
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeQualityTag", "Q1")
+                        .addArgument("rawBarcodeQualityTag", "Q2")
+                        .addArgument("rawBarcodeSequenceTags", "B1"),
+                        true},
+                // two barcode tags and only one quality (overridden)
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeSequenceTags", "B1")
+                        .addArgument("rawBarcodeSequenceTags", "B2")
+                        .addArgument("rawBarcodeQualityTag", "Q1"),
+                        true},
+                // incompatible arguments
+                {new ArgumentsBuilder()
+                        .addBooleanArgument("barcodeInReadName", true)
+                        .addArgument("rawBarcodeSequenceTags", "B1"),
+                        true},
+                // invalid qual tag names
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeQualityTag", "1A"),
+                        true},
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeQualityTag", "A1A"),
+                        true},
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeQualityTag", "A+"),
+                        true},
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeQualityTag", "+A"),
+                        true},
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeQualityTag", "1A"),
+                        true},
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeQualityTag", "A1A"),
+                        true},
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeQualityTag", "A+"),
+                        true},
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeQualityTag", "+A"),
+                        true}
+        };
+    }
+
+    @Test(dataProvider = "badArgs", expectedExceptions = CommandLineException.class)
+    public void testBadArguments(final ArgumentsBuilder args, final boolean fixQuals)
+            throws Exception {
+        args.addArgument("verbosity", "ERROR").addBooleanArgument("QUIET", true);
+        final CommandLineProgram clp = new FixBarcodesCLP(fixQuals);
+        clp.instanceMain(args.getArgsArray());
+    }
+
+    @DataProvider(name = "goodArgs")
+    public Object[][] getGoodArguments() {
+        return new Object[][] {
+                // Without fixing quality
+                // no args
+                {new ArgumentsBuilder(),
+                        false, ReadTransformer.identity().getClass()},
+                // barcodes in read name
+                {new ArgumentsBuilder()
+                        .addBooleanArgument("barcodeInReadName", true),
+                        false, FixReadNameBarcodesReadTransformer.class},
+                // barcodes in tag
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeSequenceTags", "B1"),
+                        false, FixRawBarcodeTagsReadTransformer.class},
+                // cleaning BC tag
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeSequenceTags", "null"),
+                        false, ReadTransformer.identity().getClass()},
+
+                // With fixing quality bad arguments
+                // barcodes in read name
+                {new ArgumentsBuilder()
+                        .addBooleanArgument("barcodeInReadName", true),
+                        true, FixReadNameBarcodesReadTransformer.class},
+                // barcodes in tag
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeSequenceTags", "B1"),
+                        true, FixRawBarcodeTagsReadTransformer.class},
+                // no args
+                {new ArgumentsBuilder(),
+                        true, ReadTransformer.identity().getClass()},
+                // cleaning BC tag
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeSequenceTags", "null"),
+                        true, ReadTransformer.identity().getClass()},
+                // just quality tag
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeQualityTag", "Q1"),
+                        true, FixRawBarcodeTagsReadTransformer.class},
+                // 1 barcode and quality tag
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeSequenceTags", "B1")
+                        .addArgument("rawBarcodeQualityTag", "Q1"),
+                        true, FixRawBarcodeTagsReadTransformer.class},
+                // 2 barcode and quality tags
+                {new ArgumentsBuilder()
+                        .addArgument("rawBarcodeSequenceTags", "B1")
+                        .addArgument("rawBarcodeQualityTag", "Q1")
+                        .addArgument("rawBarcodeSequenceTags", "B2")
+                        .addArgument("rawBarcodeQualityTag", "Q2"),
+                        true, FixRawBarcodeTagsReadTransformer.class}
+        };
+    }
+
+    @Test(dataProvider = "goodArgs")
+    public void testGoodArguments(final ArgumentsBuilder args, final boolean fixQuals,
+            final Class<ReadTransformer> transformerClass)
+            throws Exception {
+        // set verbosity to the minimal
+        args.addArgument("verbosity", "ERROR").addBooleanArgument("QUIET", true);
+        final CommandLineProgram clp = new FixBarcodesCLP(fixQuals);
+        // assert that the transformer is not null
+        Assert.assertEquals(clp.instanceMain(args.getArgsArray()), transformerClass);
+    }
+
+}

--- a/src/test/java/org/magicdgs/readtools/tools/conversion/StandardizeReadsIntegrationTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/conversion/StandardizeReadsIntegrationTest.java
@@ -50,30 +50,6 @@ public class StandardizeReadsIntegrationTest extends CommandLineProgramTest {
     private final File expectedPaired = getTestFile("expected_paired_standard.sam");
     private final File expectedSingle = getTestFile("expected_single_standard.sam");
 
-    @DataProvider(name = "badArgs")
-    public Object[][] getBadArguments() {
-        final ArgumentsBuilder builder = new ArgumentsBuilder()
-                .addInput(getTestFile("small_1.illumina.fq"))
-                .addOutput(new File(TEST_TEMP_DIR, "example.bam"));
-        return new Object[][] {
-                // only quality
-                {builder.addArgument("rawBarcodeQualityTag", "B2")
-                        .getArgsArray()},
-                // different length of arguments
-                {builder.addArgument("rawBarcodeSequenceTags", "B1")
-                        .addArgument("rawBarcodeQualityTag", "B3")
-                        .getArgsArray()},
-                {builder.addBooleanArgument("barcodeInReadName", true)
-                        .addArgument("rawBarcodeSequenceTags", "B4")
-                        .getArgsArray()}
-        };
-    }
-
-    @Test(dataProvider = "badArgs", expectedExceptions = CommandLineException.class)
-    public void testBadArguments(final String[] args) throws Exception {
-        runCommandLine(args);
-    }
-
     @DataProvider(name = "toStandardize")
     public Object[][] tesStandardizeReadsData() {
         return new Object[][] {


### PR DESCRIPTION
This reduce the repetition of code for tools requiring fix of barcode tags, closing #128

In addition, it includes some minor/bug fixes:

- Raw barcode tags static Strings in `RTReadUtils`
- Bug fix: validate tag names provided by the user (fixes #137)
- More tests for argument validation