### PR TITLE
Improve exception handling for writers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     }
     compile group: 'com.github.samtools', name: 'htsjdk', version: htsjdkVersion
     compile group: 'org.testng', name: 'testng', version: testngVersion
+
+    // compilation for testing
+    testCompile 'org.mockito:mockito-core:1.10.19'
 }
 
 // for managing the wrapper task

--- a/src/main/java/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode.java
+++ b/src/main/java/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode.java
@@ -34,6 +34,7 @@ import org.magicdgs.readtools.engine.ReadToolsWalker;
 import org.magicdgs.readtools.tools.barcodes.dictionary.decoder.BarcodeDecoder;
 import org.magicdgs.readtools.tools.barcodes.dictionary.decoder.BarcodeMatch;
 import org.magicdgs.readtools.metrics.barcodes.MatcherStat;
+import org.magicdgs.readtools.utils.read.ReadWriterFactory;
 import org.magicdgs.readtools.utils.read.writer.NullGATKWriter;
 
 import htsjdk.samtools.SAMFileHeader;
@@ -203,7 +204,7 @@ public final class AssignReadGroupByBarcode extends ReadToolsWalker {
 
     @Override
     public void closeTool() {
-        CloserUtil.close(writer);
-        CloserUtil.close(discardedWriter);
+        ReadWriterFactory.closeWriter(writer);
+        ReadWriterFactory.closeWriter(discardedWriter);
     }
 }

--- a/src/main/java/org/magicdgs/readtools/tools/conversion/ReadsToFastq.java
+++ b/src/main/java/org/magicdgs/readtools/tools/conversion/ReadsToFastq.java
@@ -29,6 +29,7 @@ import org.magicdgs.readtools.cmd.argumentcollections.FixBarcodeAbstractArgument
 import org.magicdgs.readtools.cmd.argumentcollections.RTOutputArgumentCollection;
 import org.magicdgs.readtools.cmd.programgroups.ReadToolsConversionProgramGroup;
 import org.magicdgs.readtools.engine.ReadToolsWalker;
+import org.magicdgs.readtools.utils.read.ReadWriterFactory;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.util.CloserUtil;
@@ -104,6 +105,6 @@ public final class ReadsToFastq extends ReadToolsWalker {
 
     @Override
     public void closeTool() {
-        CloserUtil.close(writer);
+        ReadWriterFactory.closeWriter(writer);
     }
 }

--- a/src/main/java/org/magicdgs/readtools/tools/conversion/StandardizeReads.java
+++ b/src/main/java/org/magicdgs/readtools/tools/conversion/StandardizeReads.java
@@ -28,6 +28,7 @@ import org.magicdgs.readtools.cmd.argumentcollections.FixBarcodeAbstractArgument
 import org.magicdgs.readtools.cmd.argumentcollections.RTOutputArgumentCollection;
 import org.magicdgs.readtools.cmd.programgroups.ReadToolsConversionProgramGroup;
 import org.magicdgs.readtools.engine.ReadToolsWalker;
+import org.magicdgs.readtools.utils.read.ReadWriterFactory;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.util.CloserUtil;
@@ -103,7 +104,7 @@ public final class StandardizeReads extends ReadToolsWalker {
 
     @Override
     public void closeTool() {
-        CloserUtil.close(writer);
+        ReadWriterFactory.closeWriter(writer);
     }
 
 }

--- a/src/main/java/org/magicdgs/readtools/tools/trimming/TrimReads.java
+++ b/src/main/java/org/magicdgs/readtools/tools/trimming/TrimReads.java
@@ -32,6 +32,7 @@ import org.magicdgs.readtools.cmd.programgroups.ReadToolsProgramGroup;
 import org.magicdgs.readtools.engine.ReadToolsWalker;
 import org.magicdgs.readtools.metrics.FilterMetric;
 import org.magicdgs.readtools.metrics.TrimmerMetric;
+import org.magicdgs.readtools.utils.read.ReadWriterFactory;
 import org.magicdgs.readtools.utils.read.ReservedTags;
 import org.magicdgs.readtools.utils.read.transformer.trimming.MottQualityTrimmer;
 import org.magicdgs.readtools.utils.read.transformer.trimming.TrailingNtrimmer;
@@ -227,7 +228,7 @@ public final class TrimReads extends ReadToolsWalker {
     @Override
     public void closeTool() {
         // close the three writers
-        CloserUtil.close(writer);
-        CloserUtil.close(discardedWriter);
+        ReadWriterFactory.closeWriter(writer);
+        ReadWriterFactory.closeWriter(discardedWriter);
     }
 }

--- a/src/main/java/org/magicdgs/readtools/utils/read/ReadWriterFactory.java
+++ b/src/main/java/org/magicdgs/readtools/utils/read/ReadWriterFactory.java
@@ -245,7 +245,7 @@ public final class ReadWriterFactory {
             return maybeCompressedWrap(os, outputPath);
 
         } catch (IOException e) {
-            trowCouldNotCreateOutputPath(outputPath, e);
+            throwCouldNotCreateOutputPath(outputPath, e);
         }
         throw new GATKException.ShouldNeverReachHereException("getOutputStream");
     }
@@ -304,7 +304,7 @@ public final class ReadWriterFactory {
         try {
             Files.createDirectories(outputPath.toAbsolutePath().getParent());
         } catch (final IOException e) {
-            trowCouldNotCreateOutputPath(outputPath, e);
+            throwCouldNotCreateOutputPath(outputPath, e);
         }
     }
 
@@ -313,7 +313,7 @@ public final class ReadWriterFactory {
      * path. This method should be used in the ReadWriterFactory for consistency in thrown
      * exceptions with informative messages.
      */
-    private static final void trowCouldNotCreateOutputPath(final Path path,
+    private static final void throwCouldNotCreateOutputPath(final Path path,
             final Exception e) {
         throw new UserException.CouldNotCreateOutputFile(
                 // using URI to be more informative


### PR DESCRIPTION
`UserExceptions` are expected to be informative enough for the final user to make easier the support for our toolkit. This commit fix some bugs in this exception handling by:

- Use a more consistent error message for failing opening a writer. While an exception occur, previous implementation called java.nio.Path#toFile, causing a NPE in the case of HDFS paths (for example). This is fixed by using a method which encapsulate the logic for handling this errors: it uses the URI string, the name of the exception and the message produced.
- Closing the writers throws if they cannot be closed. We were using ClosingUtils#close for out writers at the end of our tools, but this is wrong because any IOException will be silent. In the case of a failure happens while closing, we should warn the user somehow. Thus, there is a new method for achieving this in ReadWriterFactory, which is used in the tool #close method.

Note: this commit adds Mockito as dependency for testing.

Closes #163 and partially solving #106 