### PR TITLE
Remove non-gzip compression support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - HDFS support for input and output. The URI should specify the schema (__hdfs__) and the host.
-- Developer: `ReadWriterFactory` support other compression formats.
 
 ### Changed
 - Removed legacy tools

--- a/src/main/java/org/magicdgs/readtools/utils/read/ReadWriterFactory.java
+++ b/src/main/java/org/magicdgs/readtools/utils/read/ReadWriterFactory.java
@@ -247,8 +247,8 @@ public final class ReadWriterFactory {
         throw new GATKException.ShouldNeverReachHereException("getOutputStream");
     }
 
-    // wraps the output stream if it ends with a compression extension
-    // gzip is handled with HTSJDK; other formats are handled with the compressor factory
+    // wraps the output stream if it ends with a compression extension:
+    // - gzip is handled with HTSJDK
     private OutputStream maybeCompressedWrap(final OutputStream outputStream,
             final Path outputPath) throws IOException {
         // handle the gzip format with the CustomGzipOutputStream from HTSJDK for backwards-compatibility


### PR DESCRIPTION
Control for non-gzip was implemented without testing and this result in
errors while recognizing the extension. Thus, this commit remove this
support that is unused.

In the future, we will include support for bzip2 compression at least
for HDFS paths.