### PR TITLE
Reduce test verbosity

### DIFF
--- a/src/main/java/org/magicdgs/readtools/utils/tests/BaseTest.java
+++ b/src/main/java/org/magicdgs/readtools/utils/tests/BaseTest.java
@@ -26,13 +26,18 @@ package org.magicdgs.readtools.utils.tests;
 
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.util.Log;
+import org.apache.commons.io.output.NullOutputStream;
+import org.broadinstitute.hellbender.utils.LoggingUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.text.XReadLines;
 import org.testng.Assert;
 import org.testng.Reporter;
+import org.testng.annotations.BeforeSuite;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 
 /**
  * All tests for ReadTools should extend this class. It contains utilities for log results, and
@@ -45,6 +50,15 @@ public class BaseTest {
     /** Log this message so that it shows up inline during output as well as in html reports. */
     public static void log(final String message) {
         Reporter.log(message, true);
+    }
+
+    /** Print stream used for tests which requires it, such as CLP parsing. */
+    public static final PrintStream NULL_PRINT_STREAM = new PrintStream(new NullOutputStream());
+
+    /** All the tests will have only the error verbosity. */
+    @BeforeSuite
+    public void setTestVerbosity() {
+        LoggingUtils.setLoggingLevel(Log.LogLevel.ERROR);
     }
 
     /**

--- a/src/main/java/org/magicdgs/readtools/utils/tests/CommandLineProgramTest.java
+++ b/src/main/java/org/magicdgs/readtools/utils/tests/CommandLineProgramTest.java
@@ -34,6 +34,7 @@ import org.broadinstitute.hellbender.utils.test.CommandLineProgramTester;
 import org.testng.annotations.BeforeSuite;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -42,9 +43,6 @@ import java.util.List;
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
 public abstract class CommandLineProgramTest extends BaseTest implements CommandLineProgramTester {
-
-    /** Logger for the PAToK package for the tests. */
-    public static final Logger logger = LogManager.getLogger("org.magicdgs.readtools");
 
     /** Test FASTQ file (pair 1). */
     public static final File SMALL_FASTQ_1 = getInputDataFile("SRR1931701_1.fq");
@@ -65,12 +63,6 @@ public abstract class CommandLineProgramTest extends BaseTest implements Command
         return TestResourcesUtils.getReadToolsTestResource("org/magicdgs/readtools/data/" + fileName);
     }
 
-    /** All the tests will have only the debug verbosity. */
-    @BeforeSuite
-    public void setTestVerbosity() {
-        LoggingUtils.setLoggingLevel(Log.LogLevel.DEBUG);
-    }
-
     /** @return {@link #getTestedClassName()} */
     @Override
     public String getTestedToolName() {
@@ -81,5 +73,20 @@ public abstract class CommandLineProgramTest extends BaseTest implements Command
     @Override
     public Object runCommandLine(final List<String> args) {
         return new Main().instanceMain(makeCommandLineArgs(args));
+    }
+
+    /** Includes also setting QUIET=true if not present. */
+    @Override
+    public List<String> injectDefaultVerbosity(final List<String> args) {
+        // call the super
+        final List<String> verbArgs = CommandLineProgramTester.super.injectDefaultVerbosity(args);
+        for (String arg : verbArgs) {
+            if ("--QUIET".equals(arg)) {
+                return verbArgs;
+            }
+        }
+        final List<String> quietArgs = new ArrayList<>(verbArgs);
+        quietArgs.add("--QUIET");
+        return quietArgs;
     }
 }

--- a/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/BarcodeDetectorArgumentCollectionUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/BarcodeDetectorArgumentCollectionUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.cmd.argumentcollections;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.utils.tests.CommandLineProgramTest;
 
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineException;
@@ -44,7 +44,7 @@ import java.util.List;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class BarcodeDetectorArgumentCollectionUnitTest extends BaseTest {
+public class BarcodeDetectorArgumentCollectionUnitTest extends CommandLineProgramTest {
 
     @CommandLineProgramProperties(oneLineSummary = "BarcodeDetectorArgumentCollection", summary = "BarcodeDetectorArgumentCollection", programGroup = TestProgramGroup.class)
     private final static class BarcodeDetectorArgumentCollectionTool extends CommandLineProgram {
@@ -91,7 +91,7 @@ public class BarcodeDetectorArgumentCollectionUnitTest extends BaseTest {
 
     // test the validation while running a tool with customCommandLineValidation
     // should thrown
-    private static Object runBarcodeDetectorArgumentCollectionToolWithArgs(final File barcodeFile,
+    private Object runBarcodeDetectorArgumentCollectionToolWithArgs(final File barcodeFile,
             final Integer maxN, final List<Integer> maxMismatches,
             final List<Integer> minDistance) {
         final ArgumentsBuilder args = new ArgumentsBuilder()
@@ -109,7 +109,7 @@ public class BarcodeDetectorArgumentCollectionUnitTest extends BaseTest {
         }
         final BarcodeDetectorArgumentCollectionTool tool =
                 new BarcodeDetectorArgumentCollectionTool();
-        return tool.instanceMain(args.getArgsArray());
+        return tool.instanceMain(injectDefaultVerbosity(args.getArgsList()).toArray(new String[0]));
     }
 
     @DataProvider(name = "badArgumentsForGetBarcodeDecoder")

--- a/src/test/java/org/magicdgs/readtools/cmd/plugin/TrimmerPluginDescriptorUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/plugin/TrimmerPluginDescriptorUnitTest.java
@@ -215,7 +215,7 @@ public class TrimmerPluginDescriptorUnitTest extends BaseTest {
                 Collections.singletonList(new TrimmerPluginDescriptor(
                         (withDefault) ? makeDefaultTrimmerForTest() : null)));
 
-        Assert.assertTrue(clp.parseArguments(System.out, args.getArgsArray()));
+        Assert.assertTrue(clp.parseArguments(NULL_PRINT_STREAM, args.getArgsArray()));
         final TrimmerPluginDescriptor tpd = clp.getPluginDescriptor(TrimmerPluginDescriptor.class);
 
         // test the defaults classes
@@ -245,7 +245,7 @@ public class TrimmerPluginDescriptorUnitTest extends BaseTest {
     public void testAllTrimmersHelpAfterParsed() throws Exception {
         final CommandLineArgumentParser clp = new CommandLineArgumentParser(new Object(),
                 Collections.singletonList(new TrimmerPluginDescriptor(null)));
-        clp.parseArguments(System.out, new String[] {});
+        clp.parseArguments(NULL_PRINT_STREAM, new String[] {});
         Assert.assertEquals(clp.getPluginDescriptor(TrimmerPluginDescriptor.class)
                         .getAllowedValuesForDescriptorArgument("trimmer").size(),
                 NUMBER_OF_TRIMMERS_IMPLEMENTED);
@@ -303,7 +303,7 @@ public class TrimmerPluginDescriptorUnitTest extends BaseTest {
         final CommandLineArgumentParser clp = new CommandLineArgumentParser(new Object(),
                 Collections.singletonList(new TrimmerPluginDescriptor(
                         (withDefault) ? makeDefaultTrimmerForTest() : null)));
-        clp.parseArguments(System.out, args.getArgsArray());
+        clp.parseArguments(NULL_PRINT_STREAM, args.getArgsArray());
     }
 
     @DataProvider(name = "mutexArgs")
@@ -320,7 +320,7 @@ public class TrimmerPluginDescriptorUnitTest extends BaseTest {
             throws Exception {
         final CommandLineArgumentParser clp = new CommandLineArgumentParser(new Object(),
                 Collections.singletonList(new TrimmerPluginDescriptor(null)));
-        final boolean parsed = clp.parseArguments(System.out,
+        final boolean parsed = clp.parseArguments(NULL_PRINT_STREAM,
                 new ArgumentsBuilder()
                         .addBooleanArgument("disable5pTrim", disable5pTrim)
                         .addBooleanArgument("disable3pTrim", disable3pTrim)

--- a/src/test/java/org/magicdgs/readtools/engine/ReadToolsWalkerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/engine/ReadToolsWalkerUnitTest.java
@@ -33,6 +33,9 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
@@ -56,17 +59,17 @@ public class ReadToolsWalkerUnitTest extends CommandLineProgramTest {
     @DataProvider(name = "arguments")
     public Object[][] walkerArguments() {
         return new Object[][] {
-                {new String[] {"-I", getTestFileName("small.mapped.bam")}, 206, false},
-                {new String[] {"-I", getTestFileName("small_1.illumina.fq"),
-                        "-I2", getTestFileName("small_2.illumina.fq")}, 10, true}
+                {Arrays.asList("-I", getTestFileName("small.mapped.bam")), 206, false},
+                {Arrays.asList("-I", getTestFileName("small_1.illumina.fq"),
+                        "-I2", getTestFileName("small_2.illumina.fq")), 10, true}
         };
     }
 
     @Test(dataProvider = "arguments")
-    public void testReadToolsSimpleWalker(final String[] args, final int expectedReads,
+    public void testReadToolsSimpleWalker(final List<String> args, final int expectedReads,
             final boolean isPaired) throws Exception {
         final TestWalker walker = new TestWalker();
-        Assert.assertNull(walker.instanceMain(args));
+        Assert.assertNull(walker.instanceMain(injectDefaultVerbosity(args).toArray(new String[0])));
         Assert.assertEquals(walker.isPaired(), isPaired);
         Assert.assertEquals(walker.nReads, expectedReads);
         // get the program record

--- a/src/test/java/org/magicdgs/readtools/tools/trimming/TrimAndFilterPipelineUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/trimming/TrimAndFilterPipelineUnitTest.java
@@ -508,9 +508,9 @@ public class TrimAndFilterPipelineUnitTest extends BaseTest {
                 new TrimmerPluginDescriptor(defaultTrimmers)));
 
         if (defaultFilters.isEmpty()) {
-            clp.parseArguments(System.err, new String[]{});
+            clp.parseArguments(NULL_PRINT_STREAM, new String[]{});
         } else {
-            clp.parseArguments(System.err, new String[] {"--RF",
+            clp.parseArguments(NULL_PRINT_STREAM, new String[] {"--RF",
                     defaultFilters.get(0).getClass().getSimpleName()});
         }
 
@@ -537,12 +537,12 @@ public class TrimAndFilterPipelineUnitTest extends BaseTest {
         final int expectedFilters;
         if (defaultFilters.isEmpty()) {
             // parse arguments with disabling all the read filters
-            clp.parseArguments(System.err, new String[] {"--disableToolDefaultReadFilters"});
+            clp.parseArguments(NULL_PRINT_STREAM, new String[] {"--disableToolDefaultReadFilters"});
             // we only expect the completely trimmed one
             expectedFilters = 1;
         } else {
             // parse arguments with disabling all the read filters and adding the first one
-            clp.parseArguments(System.err, new String[] {
+            clp.parseArguments(NULL_PRINT_STREAM, new String[] {
                     "--disableToolDefaultReadFilters",
                     "--readFilter", defaultFilters.get(0).getClass().getSimpleName()});
             // in this case we expect two filters, the first one and the completely trimmed


### PR DESCRIPTION
Test refactoring to reduce test verbosity in both integration and unit tests:

* Using null streams instead of System.err/System.out while necessary
* Set default verbosity to error before the all suites
* Add QUIET=false as default verbosity for CLP
* Using CLP tester for some tool-related tests to inject default verbosity
* Remove CLP logger