### PR TITLE
Repackage test utilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
 
     // compilation for testing
     testCompile 'org.testng:testng:6.11'
-    testCompile 'org.mockito:mockito-core:1.10.19'
+    testCompile 'org.mockito:mockito-core:2.7.19'
 }
 
 // for managing the wrapper task

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,6 @@ repositories {
 // versions for the dependencies
 final gatkVersion = '4.alpha.2-181-g987e2f9-SNAPSHOT' // TODO: we should use the master-SNAPSHOT one is done (gatk/issue#1995)
 final htsjdkVersion = '2.9.1-9-g6d22658-SNAPSHOT' // TODO: bring back to the HTSJDK release
-final testngVersion = "6.11"
 
 dependencies {
     compile (group: 'org.broadinstitute', name: 'gatk', version: gatkVersion) {
@@ -53,9 +52,9 @@ dependencies {
         exclude module: 'testng'
     }
     compile group: 'com.github.samtools', name: 'htsjdk', version: htsjdkVersion
-    compile group: 'org.testng', name: 'testng', version: testngVersion
 
     // compilation for testing
+    testCompile 'org.testng:testng:6.11'
     testCompile 'org.mockito:mockito-core:1.10.19'
 }
 

--- a/src/test/java/org/magicdgs/readtools/BaseTest.java
+++ b/src/test/java/org/magicdgs/readtools/BaseTest.java
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package org.magicdgs.readtools.utils.tests;
+package org.magicdgs.readtools;
 
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;

--- a/src/test/java/org/magicdgs/readtools/CommandLineProgramTest.java
+++ b/src/test/java/org/magicdgs/readtools/CommandLineProgramTest.java
@@ -22,16 +22,9 @@
  * SOFTWARE.
  */
 
-package org.magicdgs.readtools.utils.tests;
+package org.magicdgs.readtools;
 
-import org.magicdgs.readtools.Main;
-
-import htsjdk.samtools.util.Log;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.broadinstitute.hellbender.utils.LoggingUtils;
 import org.broadinstitute.hellbender.utils.test.CommandLineProgramTester;
-import org.testng.annotations.BeforeSuite;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/src/test/java/org/magicdgs/readtools/RTBaseTest.java
+++ b/src/test/java/org/magicdgs/readtools/RTBaseTest.java
@@ -45,7 +45,7 @@ import java.io.PrintStream;
  *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class BaseTest {
+public class RTBaseTest {
 
     /** Log this message so that it shows up inline during output as well as in html reports. */
     public static void log(final String message) {

--- a/src/test/java/org/magicdgs/readtools/RTCommandLineProgramTest.java
+++ b/src/test/java/org/magicdgs/readtools/RTCommandLineProgramTest.java
@@ -35,7 +35,7 @@ import java.util.List;
  *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public abstract class CommandLineProgramTest extends BaseTest implements CommandLineProgramTester {
+public abstract class RTCommandLineProgramTest extends RTBaseTest implements CommandLineProgramTester {
 
     /** Test FASTQ file (pair 1). */
     public static final File SMALL_FASTQ_1 = getInputDataFile("SRR1931701_1.fq");

--- a/src/test/java/org/magicdgs/readtools/TestResourcesUtils.java
+++ b/src/test/java/org/magicdgs/readtools/TestResourcesUtils.java
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package org.magicdgs.readtools.utils.tests;
+package org.magicdgs.readtools;
 
 import java.io.File;
 

--- a/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/BarcodeDetectorArgumentCollectionUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/BarcodeDetectorArgumentCollectionUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.cmd.argumentcollections;
 
-import org.magicdgs.readtools.utils.tests.CommandLineProgramTest;
+import org.magicdgs.readtools.CommandLineProgramTest;
 
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineException;

--- a/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/BarcodeDetectorArgumentCollectionUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/BarcodeDetectorArgumentCollectionUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.cmd.argumentcollections;
 
-import org.magicdgs.readtools.CommandLineProgramTest;
+import org.magicdgs.readtools.RTCommandLineProgramTest;
 
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineException;
@@ -44,7 +44,7 @@ import java.util.List;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class BarcodeDetectorArgumentCollectionUnitTest extends CommandLineProgramTest {
+public class BarcodeDetectorArgumentCollectionUnitTest extends RTCommandLineProgramTest {
 
     @CommandLineProgramProperties(oneLineSummary = "BarcodeDetectorArgumentCollection", summary = "BarcodeDetectorArgumentCollection", programGroup = TestProgramGroup.class)
     private final static class BarcodeDetectorArgumentCollectionTool extends CommandLineProgram {

--- a/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/FixBarcodeAbstractArgumentCollectionTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/FixBarcodeAbstractArgumentCollectionTest.java
@@ -26,7 +26,7 @@ package org.magicdgs.readtools.cmd.argumentcollections;
 
 import org.magicdgs.readtools.utils.read.transformer.barcodes.FixRawBarcodeTagsReadTransformer;
 import org.magicdgs.readtools.utils.read.transformer.barcodes.FixReadNameBarcodesReadTransformer;
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineException;

--- a/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/FixBarcodeAbstractArgumentCollectionTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/FixBarcodeAbstractArgumentCollectionTest.java
@@ -26,7 +26,7 @@ package org.magicdgs.readtools.cmd.argumentcollections;
 
 import org.magicdgs.readtools.utils.read.transformer.barcodes.FixRawBarcodeTagsReadTransformer;
 import org.magicdgs.readtools.utils.read.transformer.barcodes.FixReadNameBarcodesReadTransformer;
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineException;
@@ -47,7 +47,7 @@ import java.util.List;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class FixBarcodeAbstractArgumentCollectionTest extends BaseTest {
+public class FixBarcodeAbstractArgumentCollectionTest extends RTBaseTest {
 
     @CommandLineProgramProperties(
             oneLineSummary = "Fix barcodes CLP test",

--- a/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/RTInputArgumentCollectionUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/RTInputArgumentCollectionUnitTest.java
@@ -25,7 +25,7 @@
 package org.magicdgs.readtools.cmd.argumentcollections;
 
 import org.magicdgs.readtools.engine.RTDataSource;
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/RTInputArgumentCollectionUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/RTInputArgumentCollectionUnitTest.java
@@ -25,7 +25,7 @@
 package org.magicdgs.readtools.cmd.argumentcollections;
 
 import org.magicdgs.readtools.engine.RTDataSource;
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class RTInputArgumentCollectionUnitTest extends BaseTest {
+public class RTInputArgumentCollectionUnitTest extends RTBaseTest {
 
     private static RTInputArgumentCollection getWithRequiredArguments() {
         final RTInputArgumentCollection args = new RTInputArgumentCollection();

--- a/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputBamArgumentCollectionUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputBamArgumentCollectionUnitTest.java
@@ -25,7 +25,7 @@
 package org.magicdgs.readtools.cmd.argumentcollections;
 
 import org.magicdgs.readtools.exceptions.RTUserExceptions;
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMProgramRecord;
@@ -41,7 +41,7 @@ import java.io.File;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class RTOutputBamArgumentCollectionUnitTest extends BaseTest {
+public class RTOutputBamArgumentCollectionUnitTest extends RTBaseTest {
 
     @DataProvider(name = "badOutputNames")
     public Object[][] getBadOutputNames() {

--- a/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputBamArgumentCollectionUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputBamArgumentCollectionUnitTest.java
@@ -25,7 +25,7 @@
 package org.magicdgs.readtools.cmd.argumentcollections;
 
 import org.magicdgs.readtools.exceptions.RTUserExceptions;
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMProgramRecord;

--- a/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputBamSplitArgumentCollectionUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputBamSplitArgumentCollectionUnitTest.java
@@ -26,7 +26,7 @@ package org.magicdgs.readtools.cmd.argumentcollections;
 
 import org.magicdgs.readtools.utils.read.writer.ReadToolsIOFormat;
 import org.magicdgs.readtools.utils.read.writer.SplitGATKWriter;
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMReadGroupRecord;
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class RTOutputBamSplitArgumentCollectionUnitTest extends BaseTest {
+public class RTOutputBamSplitArgumentCollectionUnitTest extends RTBaseTest {
 
     private static final List<SAMReadGroupRecord> READ_GROUPS = Arrays.asList(
             new SAMReadGroupRecord("1"), new SAMReadGroupRecord("2"), new SAMReadGroupRecord("3"));

--- a/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputBamSplitArgumentCollectionUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputBamSplitArgumentCollectionUnitTest.java
@@ -26,7 +26,7 @@ package org.magicdgs.readtools.cmd.argumentcollections;
 
 import org.magicdgs.readtools.utils.read.writer.ReadToolsIOFormat;
 import org.magicdgs.readtools.utils.read.writer.SplitGATKWriter;
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMReadGroupRecord;

--- a/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputFastqArgumentCollectionUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputFastqArgumentCollectionUnitTest.java
@@ -27,7 +27,7 @@ package org.magicdgs.readtools.cmd.argumentcollections;
 import org.magicdgs.readtools.utils.read.writer.FastqGATKWriter;
 import org.magicdgs.readtools.utils.read.writer.ReadToolsIOFormat;
 import org.magicdgs.readtools.utils.read.writer.SplitGATKWriter;
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import org.broadinstitute.hellbender.utils.read.GATKReadWriter;
@@ -46,7 +46,7 @@ import java.util.stream.Stream;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class RTOutputFastqArgumentCollectionUnitTest extends BaseTest {
+public class RTOutputFastqArgumentCollectionUnitTest extends RTBaseTest {
 
     @Test
     public void testSplitOutput() throws Exception {

--- a/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputFastqArgumentCollectionUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputFastqArgumentCollectionUnitTest.java
@@ -27,7 +27,7 @@ package org.magicdgs.readtools.cmd.argumentcollections;
 import org.magicdgs.readtools.utils.read.writer.FastqGATKWriter;
 import org.magicdgs.readtools.utils.read.writer.ReadToolsIOFormat;
 import org.magicdgs.readtools.utils.read.writer.SplitGATKWriter;
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import org.broadinstitute.hellbender.utils.read.GATKReadWriter;

--- a/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/ReadGroupArgumentCollectionUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/ReadGroupArgumentCollectionUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.cmd.argumentcollections;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.util.Iso8601Date;
@@ -34,7 +34,7 @@ import org.testng.annotations.Test;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class ReadGroupArgumentCollectionUnitTest extends BaseTest {
+public class ReadGroupArgumentCollectionUnitTest extends RTBaseTest {
 
     @Test
     public void testGetNoArgumentsReadGroup() throws Exception {

--- a/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/ReadGroupArgumentCollectionUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/argumentcollections/ReadGroupArgumentCollectionUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.cmd.argumentcollections;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.util.Iso8601Date;

--- a/src/test/java/org/magicdgs/readtools/cmd/plugin/TrimmerPluginDescriptorUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/plugin/TrimmerPluginDescriptorUnitTest.java
@@ -27,7 +27,7 @@ package org.magicdgs.readtools.cmd.plugin;
 import org.magicdgs.readtools.utils.read.transformer.trimming.CutReadTrimmer;
 import org.magicdgs.readtools.utils.read.transformer.trimming.MottQualityTrimmer;
 import org.magicdgs.readtools.utils.read.transformer.trimming.TrimmingFunction;
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import org.broadinstitute.barclay.argparser.CommandLineArgumentParser;
 import org.broadinstitute.barclay.argparser.CommandLineException;

--- a/src/test/java/org/magicdgs/readtools/cmd/plugin/TrimmerPluginDescriptorUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/cmd/plugin/TrimmerPluginDescriptorUnitTest.java
@@ -27,7 +27,7 @@ package org.magicdgs.readtools.cmd.plugin;
 import org.magicdgs.readtools.utils.read.transformer.trimming.CutReadTrimmer;
 import org.magicdgs.readtools.utils.read.transformer.trimming.MottQualityTrimmer;
 import org.magicdgs.readtools.utils.read.transformer.trimming.TrimmingFunction;
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import org.broadinstitute.barclay.argparser.CommandLineArgumentParser;
 import org.broadinstitute.barclay.argparser.CommandLineException;
@@ -49,7 +49,7 @@ import java.util.stream.Collectors;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class TrimmerPluginDescriptorUnitTest extends BaseTest {
+public class TrimmerPluginDescriptorUnitTest extends RTBaseTest {
 
     // TODO: maybe we should find another way of testing this
     // this is the number of trimmers implemented to check if a returned value is correct

--- a/src/test/java/org/magicdgs/readtools/engine/RTDataSourceUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/engine/RTDataSourceUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.engine;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMTextHeaderCodec;
@@ -45,7 +45,7 @@ import java.util.stream.Stream;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class RTDataSourceUnitTest extends BaseTest {
+public class RTDataSourceUnitTest extends RTBaseTest {
 
     private final static SAMFileHeader minimalPairedHeader = new SAMFileHeader();
 

--- a/src/test/java/org/magicdgs/readtools/engine/RTDataSourceUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/engine/RTDataSourceUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.engine;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMTextHeaderCodec;

--- a/src/test/java/org/magicdgs/readtools/engine/ReadToolsWalkerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/engine/ReadToolsWalkerUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.engine;
 
-import org.magicdgs.readtools.CommandLineProgramTest;
+import org.magicdgs.readtools.RTCommandLineProgramTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMProgramRecord;
@@ -39,7 +39,7 @@ import java.util.List;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class ReadToolsWalkerUnitTest extends CommandLineProgramTest {
+public class ReadToolsWalkerUnitTest extends RTCommandLineProgramTest {
 
     // test class
     private static class TestWalker extends ReadToolsWalker {

--- a/src/test/java/org/magicdgs/readtools/engine/ReadToolsWalkerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/engine/ReadToolsWalkerUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.engine;
 
-import org.magicdgs.readtools.utils.tests.CommandLineProgramTest;
+import org.magicdgs.readtools.CommandLineProgramTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMProgramRecord;

--- a/src/test/java/org/magicdgs/readtools/engine/sourcehandler/ReadsSourceHandlerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/engine/sourcehandler/ReadsSourceHandlerUnitTest.java
@@ -25,7 +25,7 @@
 package org.magicdgs.readtools.engine.sourcehandler;
 
 import org.magicdgs.readtools.utils.read.ReadReaderFactory;
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SamReader;

--- a/src/test/java/org/magicdgs/readtools/engine/sourcehandler/ReadsSourceHandlerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/engine/sourcehandler/ReadsSourceHandlerUnitTest.java
@@ -25,7 +25,7 @@
 package org.magicdgs.readtools.engine.sourcehandler;
 
 import org.magicdgs.readtools.utils.read.ReadReaderFactory;
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SamReader;
@@ -47,7 +47,7 @@ import java.util.List;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class ReadsSourceHandlerUnitTest extends BaseTest {
+public class ReadsSourceHandlerUnitTest extends RTBaseTest {
 
     private final static SimpleInterval INTERVAL_TO_QUERY = new SimpleInterval("2L");
 

--- a/src/test/java/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcodeIntegrationTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcodeIntegrationTest.java
@@ -25,7 +25,7 @@
 package org.magicdgs.readtools.tools.barcodes;
 
 import org.magicdgs.readtools.utils.read.ReadReaderFactory;
-import org.magicdgs.readtools.CommandLineProgramTest;
+import org.magicdgs.readtools.RTCommandLineProgramTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
@@ -46,7 +46,7 @@ import java.util.stream.IntStream;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class AssignReadGroupByBarcodeIntegrationTest extends CommandLineProgramTest {
+public class AssignReadGroupByBarcodeIntegrationTest extends RTCommandLineProgramTest {
 
     // old test files in FASTQ format -> they are modified to have the correct separator
     private final File DUAL_FASTQ_1 = getTestFile("SRR1931701.dual.barcoded_1.fq");

--- a/src/test/java/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcodeIntegrationTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcodeIntegrationTest.java
@@ -25,7 +25,7 @@
 package org.magicdgs.readtools.tools.barcodes;
 
 import org.magicdgs.readtools.utils.read.ReadReaderFactory;
-import org.magicdgs.readtools.utils.tests.CommandLineProgramTest;
+import org.magicdgs.readtools.CommandLineProgramTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;

--- a/src/test/java/org/magicdgs/readtools/tools/barcodes/dictionary/BarcodeDictionaryFactoryUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/barcodes/dictionary/BarcodeDictionaryFactoryUnitTest.java
@@ -25,7 +25,7 @@
 package org.magicdgs.readtools.tools.barcodes.dictionary;
 
 import org.magicdgs.readtools.cmd.argumentcollections.ReadGroupArgumentCollection;
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.testng.Assert;
@@ -39,7 +39,7 @@ import java.util.List;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class BarcodeDictionaryFactoryUnitTest extends BaseTest {
+public class BarcodeDictionaryFactoryUnitTest extends RTBaseTest {
 
     private final static ReadGroupArgumentCollection RG_INFO = new ReadGroupArgumentCollection();
 

--- a/src/test/java/org/magicdgs/readtools/tools/barcodes/dictionary/BarcodeDictionaryFactoryUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/barcodes/dictionary/BarcodeDictionaryFactoryUnitTest.java
@@ -25,7 +25,7 @@
 package org.magicdgs.readtools.tools.barcodes.dictionary;
 
 import org.magicdgs.readtools.cmd.argumentcollections.ReadGroupArgumentCollection;
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.testng.Assert;

--- a/src/test/java/org/magicdgs/readtools/tools/barcodes/dictionary/BarcodeDictionaryTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/barcodes/dictionary/BarcodeDictionaryTest.java
@@ -26,7 +26,7 @@ package org.magicdgs.readtools.tools.barcodes.dictionary;
 
 import org.magicdgs.readtools.ProjectProperties;
 import org.magicdgs.readtools.tools.barcodes.dictionary.decoder.BarcodeMatch;
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.SAMReadGroupRecord;
 import org.testng.Assert;
@@ -40,7 +40,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class BarcodeDictionaryTest extends BaseTest {
+public class BarcodeDictionaryTest extends RTBaseTest {
 
     private static BarcodeDictionary dictionarySingle, dictionaryDouble;
 

--- a/src/test/java/org/magicdgs/readtools/tools/barcodes/dictionary/BarcodeDictionaryTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/barcodes/dictionary/BarcodeDictionaryTest.java
@@ -26,7 +26,7 @@ package org.magicdgs.readtools.tools.barcodes.dictionary;
 
 import org.magicdgs.readtools.ProjectProperties;
 import org.magicdgs.readtools.tools.barcodes.dictionary.decoder.BarcodeMatch;
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import htsjdk.samtools.SAMReadGroupRecord;
 import org.testng.Assert;

--- a/src/test/java/org/magicdgs/readtools/tools/barcodes/dictionary/decoder/BarcodeMatchUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/barcodes/dictionary/decoder/BarcodeMatchUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.tools.barcodes.dictionary.decoder;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import org.apache.commons.lang3.StringUtils;
 import org.testng.Assert;
@@ -41,7 +41,7 @@ import java.util.Set;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class BarcodeMatchUnitTest extends BaseTest {
+public class BarcodeMatchUnitTest extends RTBaseTest {
 
     private final static Set<String> ALL_BARCODES = new LinkedHashSet<>(
             Arrays.asList("AAAA", "TTTT", "CCCC", "AATC"));

--- a/src/test/java/org/magicdgs/readtools/tools/barcodes/dictionary/decoder/BarcodeMatchUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/barcodes/dictionary/decoder/BarcodeMatchUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.tools.barcodes.dictionary.decoder;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import org.apache.commons.lang3.StringUtils;
 import org.testng.Assert;

--- a/src/test/java/org/magicdgs/readtools/tools/conversion/ReadsToDistmapIntegrationTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/conversion/ReadsToDistmapIntegrationTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.tools.conversion;
 
-import org.magicdgs.readtools.CommandLineProgramTest;
+import org.magicdgs.readtools.RTCommandLineProgramTest;
 
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
@@ -36,7 +36,7 @@ import java.io.File;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class ReadsToDistmapIntegrationTest extends CommandLineProgramTest {
+public class ReadsToDistmapIntegrationTest extends RTCommandLineProgramTest {
 
     private static final File TEST_TEMP_DIR =
             createTestTempDir(ReadsToDistmapIntegrationTest.class.getSimpleName());

--- a/src/test/java/org/magicdgs/readtools/tools/conversion/ReadsToDistmapIntegrationTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/conversion/ReadsToDistmapIntegrationTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.tools.conversion;
 
-import org.magicdgs.readtools.utils.tests.CommandLineProgramTest;
+import org.magicdgs.readtools.CommandLineProgramTest;
 
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;

--- a/src/test/java/org/magicdgs/readtools/tools/conversion/ReadsToFastqIntegrationTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/conversion/ReadsToFastqIntegrationTest.java
@@ -24,8 +24,8 @@
 
 package org.magicdgs.readtools.tools.conversion;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
-import org.magicdgs.readtools.utils.tests.CommandLineProgramTest;
+import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.CommandLineProgramTest;
 
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;

--- a/src/test/java/org/magicdgs/readtools/tools/conversion/ReadsToFastqIntegrationTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/conversion/ReadsToFastqIntegrationTest.java
@@ -24,8 +24,8 @@
 
 package org.magicdgs.readtools.tools.conversion;
 
-import org.magicdgs.readtools.BaseTest;
-import org.magicdgs.readtools.CommandLineProgramTest;
+import org.magicdgs.readtools.RTBaseTest;
+import org.magicdgs.readtools.RTCommandLineProgramTest;
 
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
@@ -41,7 +41,7 @@ import java.util.List;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class ReadsToFastqIntegrationTest extends CommandLineProgramTest {
+public class ReadsToFastqIntegrationTest extends RTCommandLineProgramTest {
 
     private static final File TEST_TEMP_DIR =
             createTestTempDir(ReadsToFastqIntegrationTest.class.getSimpleName());
@@ -130,7 +130,7 @@ public class ReadsToFastqIntegrationTest extends CommandLineProgramTest {
             assertFileIsEmpty(singleEndFile);
         } else {
             testFiles(Collections.singletonList(singleEndFile), expectedFiles);
-            pairedFiles.forEach(BaseTest::assertFileIsEmpty);
+            pairedFiles.forEach(RTBaseTest::assertFileIsEmpty);
         }
     }
 

--- a/src/test/java/org/magicdgs/readtools/tools/conversion/StandardizeReadsIntegrationTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/conversion/StandardizeReadsIntegrationTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.tools.conversion;
 
-import org.magicdgs.readtools.CommandLineProgramTest;
+import org.magicdgs.readtools.RTCommandLineProgramTest;
 
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
@@ -36,7 +36,7 @@ import java.io.File;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class StandardizeReadsIntegrationTest extends CommandLineProgramTest {
+public class StandardizeReadsIntegrationTest extends RTCommandLineProgramTest {
 
     private final static File TEST_TEMP_DIR =
             createTestTempDir(StandardizeReadsIntegrationTest.class.getSimpleName());

--- a/src/test/java/org/magicdgs/readtools/tools/conversion/StandardizeReadsIntegrationTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/conversion/StandardizeReadsIntegrationTest.java
@@ -24,20 +24,14 @@
 
 package org.magicdgs.readtools.tools.conversion;
 
-import org.magicdgs.readtools.utils.tests.CommandLineProgramTest;
+import org.magicdgs.readtools.CommandLineProgramTest;
 
-import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.SamReader;
-import htsjdk.samtools.SamReaderFactory;
-import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
-import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.util.Iterator;
 
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)

--- a/src/test/java/org/magicdgs/readtools/tools/quality/QualityEncodingDetectorIntegrationTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/quality/QualityEncodingDetectorIntegrationTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.tools.quality;
 
-import org.magicdgs.readtools.CommandLineProgramTest;
+import org.magicdgs.readtools.RTCommandLineProgramTest;
 
 import htsjdk.samtools.util.FastqQualityFormat;
 import org.broadinstitute.barclay.argparser.CommandLineException;
@@ -39,7 +39,7 @@ import java.util.Arrays;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class QualityEncodingDetectorIntegrationTest extends CommandLineProgramTest {
+public class QualityEncodingDetectorIntegrationTest extends RTCommandLineProgramTest {
 
     @Test(expectedExceptions = CommandLineException.BadArgumentValue.class)
     public void testBadArgument() throws Exception {

--- a/src/test/java/org/magicdgs/readtools/tools/quality/QualityEncodingDetectorIntegrationTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/quality/QualityEncodingDetectorIntegrationTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.tools.quality;
 
-import org.magicdgs.readtools.utils.tests.CommandLineProgramTest;
+import org.magicdgs.readtools.CommandLineProgramTest;
 
 import htsjdk.samtools.util.FastqQualityFormat;
 import org.broadinstitute.barclay.argparser.CommandLineException;

--- a/src/test/java/org/magicdgs/readtools/tools/trimming/TrimAndFilterPipelineUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/trimming/TrimAndFilterPipelineUnitTest.java
@@ -30,7 +30,7 @@ import org.magicdgs.readtools.metrics.TrimmerMetric;
 import org.magicdgs.readtools.utils.read.transformer.trimming.CutReadTrimmer;
 import org.magicdgs.readtools.utils.read.transformer.trimming.TrailingNtrimmer;
 import org.magicdgs.readtools.utils.read.transformer.trimming.TrimmingFunction;
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import org.broadinstitute.barclay.argparser.CommandLineArgumentParser;
 import org.broadinstitute.barclay.argparser.CommandLineException;
@@ -55,7 +55,7 @@ import java.util.stream.IntStream;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class TrimAndFilterPipelineUnitTest extends BaseTest {
+public class TrimAndFilterPipelineUnitTest extends RTBaseTest {
 
     @DataProvider
     public Object[][] badParams() {

--- a/src/test/java/org/magicdgs/readtools/tools/trimming/TrimAndFilterPipelineUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/trimming/TrimAndFilterPipelineUnitTest.java
@@ -30,7 +30,7 @@ import org.magicdgs.readtools.metrics.TrimmerMetric;
 import org.magicdgs.readtools.utils.read.transformer.trimming.CutReadTrimmer;
 import org.magicdgs.readtools.utils.read.transformer.trimming.TrailingNtrimmer;
 import org.magicdgs.readtools.utils.read.transformer.trimming.TrimmingFunction;
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import org.broadinstitute.barclay.argparser.CommandLineArgumentParser;
 import org.broadinstitute.barclay.argparser.CommandLineException;

--- a/src/test/java/org/magicdgs/readtools/tools/trimming/TrimReadsIntegrationTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/trimming/TrimReadsIntegrationTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.tools.trimming;
 
-import org.magicdgs.readtools.utils.tests.CommandLineProgramTest;
+import org.magicdgs.readtools.CommandLineProgramTest;
 
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;

--- a/src/test/java/org/magicdgs/readtools/tools/trimming/TrimReadsIntegrationTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/trimming/TrimReadsIntegrationTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.tools.trimming;
 
-import org.magicdgs.readtools.CommandLineProgramTest;
+import org.magicdgs.readtools.RTCommandLineProgramTest;
 
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
@@ -37,7 +37,7 @@ import java.io.File;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class TrimReadsIntegrationTest extends CommandLineProgramTest {
+public class TrimReadsIntegrationTest extends RTCommandLineProgramTest {
 
     // temp directory for all the tests
     private final static File TEST_TEMP_DIR =

--- a/src/test/java/org/magicdgs/readtools/utils/distmap/DistmapEncoderUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/distmap/DistmapEncoderUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.distmap;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.testng.Assert;
@@ -35,7 +35,7 @@ import scala.Tuple2;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class DistmapEncoderUnitTest extends BaseTest {
+public class DistmapEncoderUnitTest extends RTBaseTest {
 
     @DataProvider(name = "singleEnd")
     public Object[][] getDistmapSinleReadStrings() {

--- a/src/test/java/org/magicdgs/readtools/utils/distmap/DistmapEncoderUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/distmap/DistmapEncoderUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.distmap;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.testng.Assert;

--- a/src/test/java/org/magicdgs/readtools/utils/distmap/DistmapGATKWriterUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/distmap/DistmapGATKWriterUnitTest.java
@@ -25,7 +25,7 @@
 package org.magicdgs.readtools.utils.distmap;
 
 import org.magicdgs.readtools.utils.read.ReadWriterFactory;
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
@@ -44,7 +44,7 @@ import java.io.Writer;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class DistmapGATKWriterUnitTest extends BaseTest {
+public class DistmapGATKWriterUnitTest extends RTBaseTest {
 
     private static final File TEST_TMP_DIR = createTestTempDir("DistmapGATKWriterUnitTest");
 

--- a/src/test/java/org/magicdgs/readtools/utils/distmap/DistmapGATKWriterUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/distmap/DistmapGATKWriterUnitTest.java
@@ -25,7 +25,7 @@
 package org.magicdgs.readtools.utils.distmap;
 
 import org.magicdgs.readtools.utils.read.ReadWriterFactory;
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;

--- a/src/test/java/org/magicdgs/readtools/utils/fastq/BarcodeMethodsTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/fastq/BarcodeMethodsTest.java
@@ -27,7 +27,7 @@ package org.magicdgs.readtools.utils.fastq;
 import static org.magicdgs.readtools.utils.fastq.BarcodeMethods.getNameWithoutBarcode;
 import static org.magicdgs.readtools.utils.fastq.BarcodeMethods.getOnlyBarcodeFromName;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;

--- a/src/test/java/org/magicdgs/readtools/utils/fastq/BarcodeMethodsTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/fastq/BarcodeMethodsTest.java
@@ -27,13 +27,13 @@ package org.magicdgs.readtools.utils.fastq;
 import static org.magicdgs.readtools.utils.fastq.BarcodeMethods.getNameWithoutBarcode;
 import static org.magicdgs.readtools.utils.fastq.BarcodeMethods.getOnlyBarcodeFromName;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class BarcodeMethodsTest extends BaseTest {
+public class BarcodeMethodsTest extends RTBaseTest {
 
     private static final String basename = "Record1";
 

--- a/src/test/java/org/magicdgs/readtools/utils/fastq/FastqReadNameEncodingUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/fastq/FastqReadNameEncodingUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.fastq;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.util.SequenceUtil;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
@@ -36,7 +36,7 @@ import org.testng.annotations.Test;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class FastqReadNameEncodingUnitTest extends BaseTest {
+public class FastqReadNameEncodingUnitTest extends RTBaseTest {
 
     @DataProvider
     public Object[][] encodingData() throws Exception {

--- a/src/test/java/org/magicdgs/readtools/utils/fastq/FastqReadNameEncodingUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/fastq/FastqReadNameEncodingUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.fastq;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import htsjdk.samtools.util.SequenceUtil;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;

--- a/src/test/java/org/magicdgs/readtools/utils/iterators/FastqToReadIteratorUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/iterators/FastqToReadIteratorUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.iterators;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.fastq.FastqRecord;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
@@ -41,7 +41,7 @@ import java.util.NoSuchElementException;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class FastqToReadIteratorUnitTest extends BaseTest {
+public class FastqToReadIteratorUnitTest extends RTBaseTest {
 
     @DataProvider(name = "iterators")
     public Object[][] iteratorDataProvider() throws Exception {

--- a/src/test/java/org/magicdgs/readtools/utils/iterators/FastqToReadIteratorUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/iterators/FastqToReadIteratorUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.iterators;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import htsjdk.samtools.fastq.FastqRecord;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;

--- a/src/test/java/org/magicdgs/readtools/utils/iterators/InterleaveGATKReadIteratorsUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/iterators/InterleaveGATKReadIteratorsUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.iterators;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import htsjdk.samtools.TextCigarCodec;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;

--- a/src/test/java/org/magicdgs/readtools/utils/iterators/InterleaveGATKReadIteratorsUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/iterators/InterleaveGATKReadIteratorsUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.iterators;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.TextCigarCodec;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
@@ -40,7 +40,7 @@ import java.util.stream.Stream;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class InterleaveGATKReadIteratorsUnitTest extends BaseTest {
+public class InterleaveGATKReadIteratorsUnitTest extends RTBaseTest {
 
     private Iterator<GATKRead> makeReadsIterator(final String name) {
         return Arrays.asList(

--- a/src/test/java/org/magicdgs/readtools/utils/iterators/ReadTransformerIteratorUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/iterators/ReadTransformerIteratorUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.iterators;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import htsjdk.samtools.CigarOperator;
 import org.broadinstitute.hellbender.transformers.ReadTransformer;

--- a/src/test/java/org/magicdgs/readtools/utils/iterators/ReadTransformerIteratorUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/iterators/ReadTransformerIteratorUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.iterators;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.CigarOperator;
 import org.broadinstitute.hellbender.transformers.ReadTransformer;
@@ -41,7 +41,7 @@ import java.util.function.Predicate;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class ReadTransformerIteratorUnitTest extends BaseTest {
+public class ReadTransformerIteratorUnitTest extends RTBaseTest {
 
     private Iterator<GATKRead> makeReadsIterator() {
         return Arrays.asList(

--- a/src/test/java/org/magicdgs/readtools/utils/iterators/paired/GATKReadPairedIteratorUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/iterators/paired/GATKReadPairedIteratorUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.iterators.paired;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;

--- a/src/test/java/org/magicdgs/readtools/utils/iterators/paired/GATKReadPairedIteratorUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/iterators/paired/GATKReadPairedIteratorUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.iterators.paired;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
@@ -45,7 +45,7 @@ import java.util.NoSuchElementException;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class GATKReadPairedIteratorUnitTest extends BaseTest {
+public class GATKReadPairedIteratorUnitTest extends RTBaseTest {
 
     private final static SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
 

--- a/src/test/java/org/magicdgs/readtools/utils/read/FastqGATKReadUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/FastqGATKReadUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import htsjdk.samtools.SAMTag;
 import htsjdk.samtools.fastq.FastqRecord;

--- a/src/test/java/org/magicdgs/readtools/utils/read/FastqGATKReadUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/FastqGATKReadUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.SAMTag;
 import htsjdk.samtools.fastq.FastqRecord;
@@ -41,7 +41,7 @@ import java.util.List;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class FastqGATKReadUnitTest extends BaseTest {
+public class FastqGATKReadUnitTest extends RTBaseTest {
 
     @DataProvider(name = "fastqRecordData")
     public Iterator<Object[]> fastqRecordDataProvider() {

--- a/src/test/java/org/magicdgs/readtools/utils/read/RTReadUtilsUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/RTReadUtilsUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import org.apache.commons.lang3.tuple.Pair;
@@ -45,7 +45,7 @@ import java.util.UUID;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class RTReadUtilsUnitTest extends BaseTest {
+public class RTReadUtilsUnitTest extends RTBaseTest {
 
     private static final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
     private static final List<String> twoTags = Arrays.asList("B1", "B2");

--- a/src/test/java/org/magicdgs/readtools/utils/read/RTReadUtilsUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/RTReadUtilsUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import org.apache.commons.lang3.tuple.Pair;

--- a/src/test/java/org/magicdgs/readtools/utils/read/ReadWriterFactoryUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/ReadWriterFactoryUnitTest.java
@@ -27,7 +27,7 @@ package org.magicdgs.readtools.utils.read;
 import org.magicdgs.readtools.exceptions.RTUserExceptions;
 import org.magicdgs.readtools.utils.read.writer.FastqGATKWriter;
 import org.magicdgs.readtools.utils.read.writer.NullGATKWriter;
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -51,7 +51,7 @@ import java.util.List;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class ReadWriterFactoryUnitTest extends BaseTest {
+public class ReadWriterFactoryUnitTest extends RTBaseTest {
 
     // this is the test read with 5 bases (default one)
     private final static GATKRead DEFAULT_READ_TO_TEST = ArtificialReadUtils

--- a/src/test/java/org/magicdgs/readtools/utils/read/ReadWriterFactoryUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/ReadWriterFactoryUnitTest.java
@@ -27,7 +27,7 @@ package org.magicdgs.readtools.utils.read;
 import org.magicdgs.readtools.exceptions.RTUserExceptions;
 import org.magicdgs.readtools.utils.read.writer.FastqGATKWriter;
 import org.magicdgs.readtools.utils.read.writer.NullGATKWriter;
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import org.broadinstitute.hellbender.exceptions.UserException;

--- a/src/test/java/org/magicdgs/readtools/utils/read/filter/CompletelyTrimFilterUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/filter/CompletelyTrimFilterUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read.filter;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;

--- a/src/test/java/org/magicdgs/readtools/utils/read/filter/CompletelyTrimFilterUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/filter/CompletelyTrimFilterUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read.filter;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
@@ -36,7 +36,7 @@ import org.testng.annotations.Test;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class CompletelyTrimFilterUnitTest extends BaseTest {
+public class CompletelyTrimFilterUnitTest extends RTBaseTest {
 
     @DataProvider(name  = "reads")
     public Object[][] toFilterReads() {

--- a/src/test/java/org/magicdgs/readtools/utils/read/transformer/CheckQualityReadTransformerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/transformer/CheckQualityReadTransformerUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read.transformer;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMUtils;
@@ -41,7 +41,7 @@ import java.util.Iterator;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class CheckQualityReadTransformerUnitTest extends BaseTest {
+public class CheckQualityReadTransformerUnitTest extends RTBaseTest {
 
     private static final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
 

--- a/src/test/java/org/magicdgs/readtools/utils/read/transformer/CheckQualityReadTransformerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/transformer/CheckQualityReadTransformerUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read.transformer;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMUtils;

--- a/src/test/java/org/magicdgs/readtools/utils/read/transformer/SolexaToSangerReadTransformerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/transformer/SolexaToSangerReadTransformerUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read.transformer;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMUtils;
@@ -42,7 +42,7 @@ import java.util.Iterator;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class SolexaToSangerReadTransformerUnitTest extends BaseTest {
+public class SolexaToSangerReadTransformerUnitTest extends RTBaseTest {
 
     private static final SolexaToSangerReadTransformer transformer =
             new SolexaToSangerReadTransformer();

--- a/src/test/java/org/magicdgs/readtools/utils/read/transformer/SolexaToSangerReadTransformerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/transformer/SolexaToSangerReadTransformerUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read.transformer;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMUtils;

--- a/src/test/java/org/magicdgs/readtools/utils/read/transformer/barcodes/FixRawBarcodeTagsReadTransformerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/transformer/barcodes/FixRawBarcodeTagsReadTransformerUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read.transformer.barcodes;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import org.broadinstitute.hellbender.transformers.ReadTransformer;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;

--- a/src/test/java/org/magicdgs/readtools/utils/read/transformer/barcodes/FixRawBarcodeTagsReadTransformerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/transformer/barcodes/FixRawBarcodeTagsReadTransformerUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read.transformer.barcodes;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import org.broadinstitute.hellbender.transformers.ReadTransformer;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
@@ -40,7 +40,7 @@ import java.util.List;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class FixRawBarcodeTagsReadTransformerUnitTest extends BaseTest {
+public class FixRawBarcodeTagsReadTransformerUnitTest extends RTBaseTest {
 
     private static final GATKRead read = ArtificialReadUtils.createArtificialUnmappedRead(
             ArtificialReadUtils.createArtificialSamHeader(),

--- a/src/test/java/org/magicdgs/readtools/utils/read/transformer/barcodes/FixReadNameBarcodesReadTransformerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/transformer/barcodes/FixReadNameBarcodesReadTransformerUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read.transformer.barcodes;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import org.broadinstitute.hellbender.transformers.ReadTransformer;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
@@ -35,7 +35,7 @@ import org.testng.annotations.Test;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class FixReadNameBarcodesReadTransformerUnitTest extends BaseTest {
+public class FixReadNameBarcodesReadTransformerUnitTest extends RTBaseTest {
 
     private static final GATKRead READ = ArtificialReadUtils.createArtificialUnmappedRead(
             ArtificialReadUtils.createArtificialSamHeader(),

--- a/src/test/java/org/magicdgs/readtools/utils/read/transformer/barcodes/FixReadNameBarcodesReadTransformerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/transformer/barcodes/FixReadNameBarcodesReadTransformerUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read.transformer.barcodes;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import org.broadinstitute.hellbender.transformers.ReadTransformer;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;

--- a/src/test/java/org/magicdgs/readtools/utils/read/transformer/trimming/ApplyTrimResultReadTransfomerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/transformer/trimming/ApplyTrimResultReadTransfomerUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read.transformer.trimming;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import htsjdk.samtools.Cigar;
 import htsjdk.samtools.SAMFileHeader;

--- a/src/test/java/org/magicdgs/readtools/utils/read/transformer/trimming/ApplyTrimResultReadTransfomerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/transformer/trimming/ApplyTrimResultReadTransfomerUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read.transformer.trimming;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.Cigar;
 import htsjdk.samtools.SAMFileHeader;
@@ -45,7 +45,7 @@ import java.util.List;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class ApplyTrimResultReadTransfomerUnitTest extends BaseTest {
+public class ApplyTrimResultReadTransfomerUnitTest extends RTBaseTest {
 
     // transformer to test
     private static final ReadTransformer transformer = new ApplyTrimResultReadTransfomer();

--- a/src/test/java/org/magicdgs/readtools/utils/read/transformer/trimming/CutReadTrimmerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/transformer/trimming/CutReadTrimmerUnitTest.java
@@ -25,7 +25,7 @@
 package org.magicdgs.readtools.utils.read.transformer.trimming;
 
 import org.magicdgs.readtools.utils.read.RTReadUtils;
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
@@ -41,7 +41,7 @@ import java.util.List;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class CutReadTrimmerUnitTest extends BaseTest {
+public class CutReadTrimmerUnitTest extends RTBaseTest {
 
     @DataProvider
     public Object[][] badArgs() {

--- a/src/test/java/org/magicdgs/readtools/utils/read/transformer/trimming/CutReadTrimmerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/transformer/trimming/CutReadTrimmerUnitTest.java
@@ -25,7 +25,7 @@
 package org.magicdgs.readtools.utils.read.transformer.trimming;
 
 import org.magicdgs.readtools.utils.read.RTReadUtils;
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;

--- a/src/test/java/org/magicdgs/readtools/utils/read/transformer/trimming/MottQualityTrimmerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/transformer/trimming/MottQualityTrimmerUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read.transformer.trimming;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 import org.magicdgs.readtools.utils.trimming.TrimmingUtilTest;
 
 import org.broadinstitute.barclay.argparser.CommandLineException;

--- a/src/test/java/org/magicdgs/readtools/utils/read/transformer/trimming/MottQualityTrimmerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/transformer/trimming/MottQualityTrimmerUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read.transformer.trimming;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 import org.magicdgs.readtools.utils.trimming.TrimmingUtilTest;
 
 import org.broadinstitute.barclay.argparser.CommandLineException;
@@ -38,7 +38,7 @@ import org.testng.annotations.Test;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class MottQualityTrimmerUnitTest extends BaseTest {
+public class MottQualityTrimmerUnitTest extends RTBaseTest {
 
     @DataProvider(name = "badArgs")
     public Object[][] badQualityThresholds() {

--- a/src/test/java/org/magicdgs/readtools/utils/read/transformer/trimming/TrailingNtrimmerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/transformer/trimming/TrailingNtrimmerUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read.transformer.trimming;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 import org.magicdgs.readtools.utils.trimming.TrimmingUtilTest;
 
 import org.broadinstitute.hellbender.utils.Utils;
@@ -36,7 +36,7 @@ import org.testng.annotations.Test;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class TrailingNtrimmerUnitTest extends BaseTest {
+public class TrailingNtrimmerUnitTest extends RTBaseTest {
 
     // trimmmer to test
     private final static TrimmingFunction TRIMMER = new TrailingNtrimmer();

--- a/src/test/java/org/magicdgs/readtools/utils/read/transformer/trimming/TrailingNtrimmerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/transformer/trimming/TrailingNtrimmerUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read.transformer.trimming;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 import org.magicdgs.readtools.utils.trimming.TrimmingUtilTest;
 
 import org.broadinstitute.hellbender.utils.Utils;

--- a/src/test/java/org/magicdgs/readtools/utils/read/transformer/trimming/TrimmingFunctionUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/transformer/trimming/TrimmingFunctionUnitTest.java
@@ -25,7 +25,7 @@
 package org.magicdgs.readtools.utils.read.transformer.trimming;
 
 import org.magicdgs.readtools.utils.read.RTReadUtils;
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;

--- a/src/test/java/org/magicdgs/readtools/utils/read/transformer/trimming/TrimmingFunctionUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/transformer/trimming/TrimmingFunctionUnitTest.java
@@ -25,7 +25,7 @@
 package org.magicdgs.readtools.utils.read.transformer.trimming;
 
 import org.magicdgs.readtools.utils.read.RTReadUtils;
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
@@ -38,7 +38,7 @@ import java.util.function.Consumer;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class TrimmingFunctionUnitTest extends BaseTest {
+public class TrimmingFunctionUnitTest extends RTBaseTest {
 
     /** Use for testing methods with trimming functions that does not require an implementation. */
     public static class NoOpTrimmingFunction extends TrimmingFunction {

--- a/src/test/java/org/magicdgs/readtools/utils/read/writer/FastqGATKWriterUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/writer/FastqGATKWriterUnitTest.java
@@ -25,7 +25,7 @@
 package org.magicdgs.readtools.utils.read.writer;
 
 import org.magicdgs.readtools.utils.iterators.FastqToReadIterator;
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.fastq.FastqReader;
 import htsjdk.samtools.fastq.FastqWriterFactory;
@@ -45,7 +45,7 @@ import java.util.List;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class FastqGATKWriterUnitTest extends BaseTest {
+public class FastqGATKWriterUnitTest extends RTBaseTest {
 
     @DataProvider(name = "readsToWrite")
     public Object[][] getReadList() throws Exception {

--- a/src/test/java/org/magicdgs/readtools/utils/read/writer/FastqGATKWriterUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/writer/FastqGATKWriterUnitTest.java
@@ -25,7 +25,7 @@
 package org.magicdgs.readtools.utils.read.writer;
 
 import org.magicdgs.readtools.utils.iterators.FastqToReadIterator;
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import htsjdk.samtools.fastq.FastqReader;
 import htsjdk.samtools.fastq.FastqWriterFactory;

--- a/src/test/java/org/magicdgs/readtools/utils/read/writer/NullGATKWriterUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/writer/NullGATKWriterUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read.writer;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.testng.annotations.Test;
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class NullGATKWriterUnitTest extends BaseTest {
+public class NullGATKWriterUnitTest extends RTBaseTest {
 
     // this is only going through the code, but doing nothing else
     @Test

--- a/src/test/java/org/magicdgs/readtools/utils/read/writer/NullGATKWriterUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/writer/NullGATKWriterUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read.writer;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.testng.annotations.Test;

--- a/src/test/java/org/magicdgs/readtools/utils/read/writer/PairEndSplitterUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/writer/PairEndSplitterUnitTest.java
@@ -25,7 +25,7 @@
 package org.magicdgs.readtools.utils.read.writer;
 
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;

--- a/src/test/java/org/magicdgs/readtools/utils/read/writer/PairEndSplitterUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/writer/PairEndSplitterUnitTest.java
@@ -25,7 +25,7 @@
 package org.magicdgs.readtools.utils.read.writer;
 
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
@@ -40,7 +40,7 @@ import java.util.List;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class PairEndSplitterUnitTest extends BaseTest {
+public class PairEndSplitterUnitTest extends RTBaseTest {
 
     private final static PairEndSplitter SPLITTER = new PairEndSplitter();
 

--- a/src/test/java/org/magicdgs/readtools/utils/read/writer/ReadToolsIOFormatUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/writer/ReadToolsIOFormatUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read.writer;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class ReadToolsIOFormatUnitTest extends BaseTest {
+public class ReadToolsIOFormatUnitTest extends RTBaseTest {
 
     @DataProvider(name = "formats")
     public Object[][] getFormats() {

--- a/src/test/java/org/magicdgs/readtools/utils/read/writer/ReadToolsIOFormatUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/writer/ReadToolsIOFormatUnitTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.read.writer;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;

--- a/src/test/java/org/magicdgs/readtools/utils/read/writer/SplitGATKWriterUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/writer/SplitGATKWriterUnitTest.java
@@ -27,7 +27,7 @@ package org.magicdgs.readtools.utils.read.writer;
 import org.magicdgs.readtools.engine.sourcehandler.ReadsSourceHandler;
 import org.magicdgs.readtools.utils.read.ReadReaderFactory;
 import org.magicdgs.readtools.utils.read.ReadWriterFactory;
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMReadGroupRecord;
@@ -58,7 +58,7 @@ import java.util.stream.IntStream;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class SplitGATKWriterUnitTest extends BaseTest {
+public class SplitGATKWriterUnitTest extends RTBaseTest {
 
     // test directory for outputs
     private final static File TEMP_TEST_DIR =

--- a/src/test/java/org/magicdgs/readtools/utils/read/writer/SplitGATKWriterUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/writer/SplitGATKWriterUnitTest.java
@@ -27,7 +27,7 @@ package org.magicdgs.readtools.utils.read.writer;
 import org.magicdgs.readtools.engine.sourcehandler.ReadsSourceHandler;
 import org.magicdgs.readtools.utils.read.ReadReaderFactory;
 import org.magicdgs.readtools.utils.read.ReadWriterFactory;
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMReadGroupRecord;

--- a/src/test/java/org/magicdgs/readtools/utils/trimming/TrimmingUtilTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/trimming/TrimmingUtilTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.trimming;
 
-import org.magicdgs.readtools.utils.tests.BaseTest;
+import org.magicdgs.readtools.BaseTest;
 
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;

--- a/src/test/java/org/magicdgs/readtools/utils/trimming/TrimmingUtilTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/trimming/TrimmingUtilTest.java
@@ -24,7 +24,7 @@
 
 package org.magicdgs.readtools.utils.trimming;
 
-import org.magicdgs.readtools.BaseTest;
+import org.magicdgs.readtools.RTBaseTest;
 
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class TrimmingUtilTest extends BaseTest {
+public class TrimmingUtilTest extends RTBaseTest {
 
     @DataProvider(name = "trimMottData")
     public static Object[][] trimMottData() {


### PR DESCRIPTION
* Move main.readtools.utils.tests to test.readtools
* Rename base testing classes to include RT
* TestNG as a compileTest dependency
* Update mockito to version 2