### PR TITLE
Improve .metrics file testing

### DIFF
--- a/src/test/java/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcodeIntegrationTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcodeIntegrationTest.java
@@ -191,7 +191,7 @@ public class AssignReadGroupByBarcodeIntegrationTest extends RTCommandLineProgra
         Assert.assertNull(runCommandLine(builder));
 
         // first check the metrics file -> the metrics file is the same
-        IntegrationTestSpec.assertEqualTextFiles(new File(actualOutputPrefix + ".metrics"),
+        metricsFileConcordance(new File(actualOutputPrefix + ".metrics"),
                 getTestFile(testName + ".metrics"));
 
         testSamFileEquivalentForBarcodeDetection(new File(actualOutputPrefix + "_discarded.sam"),

--- a/src/test/java/org/magicdgs/readtools/tools/trimming/TrimReadsIntegrationTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/trimming/TrimReadsIntegrationTest.java
@@ -119,11 +119,8 @@ public class TrimReadsIntegrationTest extends RTCommandLineProgramTest {
         // running the command line
         runCommandLine(args);
 
-        // check the metrics file -> all the headers are removed as comments
-        // this prevents for failing when the metrics are changing the package (discouraged)
-        // and failing because of the header -> this is really necessary for the metrics files
-        IntegrationTestSpec.assertEqualTextFiles(metricsOutput,getTestFile(testName + ".metrics"),
-                "#");
+        // check the metrics file
+        metricsFileConcordance(metricsOutput,getTestFile(testName + ".metrics"));
 
         // TODO: we are checking files as text files, but maybe we shouldn't
         // check the output file


### PR DESCRIPTION
This commit improves the test of .metrics files by creating a new method in `RTCommandLineProgramTest` for encapsulating its comparison. The following inconsistencies are fixed with this:

* `AssignReadGroupByBarcode` was testing as a plain-text for full concordance. This was preventing #153 to be implemented and tested at the same time for broken metrics files.
* `TrimReads` was testing all the file without the lines starting with "#". This approach is not testing for re-packaging of classes and/or re-implementation of some headers.