### PR TITLE
Improve barcode metrics

### DIFF
--- a/src/main/java/org/magicdgs/readtools/metrics/barcodes/MatcherStat.java
+++ b/src/main/java/org/magicdgs/readtools/metrics/barcodes/MatcherStat.java
@@ -46,9 +46,15 @@ public class MatcherStat extends MetricBase {
      */
     public int RECORDS;
 
+    /**
+     * Percentage of records for this sequence.
+     */
+    public double PCT_RECORDS;
+
     public MatcherStat(String barcode, String sample) {
         this.BARCODE = barcode;
         this.SAMPLE = sample;
         this.RECORDS = 0;
+        this.PCT_RECORDS = 0.0;
     }
 }

--- a/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testBamBarcodeDetector.metrics
+++ b/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testBamBarcodeDetector.metrics
@@ -1,19 +1,26 @@
+## htsjdk.samtools.metrics.StringHeader
+# org.magicdgs.readtools.tools.barcodes.AssignReadGroupByBarcode  --output src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testBamBarcodeDetector --outputFormat SAM --splitBySample false --addOutputSAMProgramRecord false --forceOverwrite true --barcodeFile src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/unique.barcodes --keepDiscarded true --barcodeInReadName true --input src/test/resources/org/magicdgs/readtools/data/example.mapped.sam --verbosity ERROR --QUIET true  --splitByReadGroup false --splitByLibrary false --createOutputBamIndex true --createOutputBamMD5 false --maximumMismatches 0 --minimumDistance 1 --nNoMismatch false --rawBarcodeSequenceTags BC --secondsBetweenProgressUpdates 10.0 --readValidationStringency SILENT --interleavedInput false --help false --version false --showHidden false --use_jdk_deflater false --use_jdk_inflater false
+## htsjdk.samtools.metrics.StringHeader
+# Started on: April 7, 2017 4:24:16 PM CEST
+
+
+
 ## org.magicdgs.readtools.metrics.barcodes.BarcodeDetector
 # No match: 0	Discarded by N: 0	Discarded by mismatch: 10	Discarded by distance: 0
 
 ## METRICS CLASS	org.magicdgs.readtools.metrics.barcodes.MatcherStat
-SAMPLE	BARCODE	RECORDS
-sample1	ATTACTCG	12
-sample2	TCCGGAGA	10
-sample3	CGCTCATT	18
-sample4	GAGATTCC	18
-sample5	ATTCAGAA	10
-sample6	GAATTCGT	32
-sample7	CTGAAGCT	30
-sample8	TAATGCGC	16
-sample9	CGGCTATG	20
-sample1	TCCGCGAA	30
-UNKNOWN	UNKNOWN	10
+SAMPLE	BARCODE	RECORDS	PCT_RECORDS
+sample1	ATTACTCG	12	5.825243
+sample2	TCCGGAGA	10	4.854369
+sample3	CGCTCATT	18	8.737864
+sample4	GAGATTCC	18	8.737864
+sample5	ATTCAGAA	10	4.854369
+sample6	GAATTCGT	32	15.533981
+sample7	CTGAAGCT	30	14.563107
+sample8	TAATGCGC	16	7.76699
+sample9	CGGCTATG	20	9.708738
+sample1	TCCGCGAA	30	14.563107
+UNKNOWN	UNKNOWN	10	4.854369
 
 
 

--- a/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testBamBarcodeDetectorSplit.metrics
+++ b/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testBamBarcodeDetectorSplit.metrics
@@ -1,19 +1,26 @@
+## htsjdk.samtools.metrics.StringHeader
+# org.magicdgs.readtools.tools.barcodes.AssignReadGroupByBarcode  --output src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testBamBarcodeDetectorSplit --outputFormat SAM --splitBySample true --addOutputSAMProgramRecord false --forceOverwrite true --barcodeFile src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/unique.barcodes --keepDiscarded true --barcodeInReadName true --input src/test/resources/org/magicdgs/readtools/data/example.mapped.sam --verbosity ERROR --QUIET true  --splitByReadGroup false --splitByLibrary false --createOutputBamIndex true --createOutputBamMD5 false --maximumMismatches 0 --minimumDistance 1 --nNoMismatch false --rawBarcodeSequenceTags BC --secondsBetweenProgressUpdates 10.0 --readValidationStringency SILENT --interleavedInput false --help false --version false --showHidden false --use_jdk_deflater false --use_jdk_inflater false
+## htsjdk.samtools.metrics.StringHeader
+# Started on: April 7, 2017 4:24:16 PM CEST
+
+
+
 ## org.magicdgs.readtools.metrics.barcodes.BarcodeDetector
 # No match: 0	Discarded by N: 0	Discarded by mismatch: 10	Discarded by distance: 0
 
 ## METRICS CLASS	org.magicdgs.readtools.metrics.barcodes.MatcherStat
-SAMPLE	BARCODE	RECORDS
-sample1	ATTACTCG	12
-sample2	TCCGGAGA	10
-sample3	CGCTCATT	18
-sample4	GAGATTCC	18
-sample5	ATTCAGAA	10
-sample6	GAATTCGT	32
-sample7	CTGAAGCT	30
-sample8	TAATGCGC	16
-sample9	CGGCTATG	20
-sample1	TCCGCGAA	30
-UNKNOWN	UNKNOWN	10
+SAMPLE	BARCODE	RECORDS	PCT_RECORDS
+sample1	ATTACTCG	12	5.825243
+sample2	TCCGGAGA	10	4.854369
+sample3	CGCTCATT	18	8.737864
+sample4	GAGATTCC	18	8.737864
+sample5	ATTCAGAA	10	4.854369
+sample6	GAATTCGT	32	15.533981
+sample7	CTGAAGCT	30	14.563107
+sample8	TAATGCGC	16	7.76699
+sample9	CGGCTATG	20	9.708738
+sample1	TCCGCGAA	30	14.563107
+UNKNOWN	UNKNOWN	10	4.854369
 
 
 

--- a/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testPairEndDefaultParameters.metrics
+++ b/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testPairEndDefaultParameters.metrics
@@ -1,19 +1,26 @@
+## htsjdk.samtools.metrics.StringHeader
+# org.magicdgs.readtools.tools.barcodes.AssignReadGroupByBarcode  --output src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testPairEndDefaultParameters --outputFormat SAM --splitBySample false --addOutputSAMProgramRecord false --forceOverwrite true --barcodeFile src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/dual.barcodes --keepDiscarded true --input src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/SRR1931701.dual.barcoded_1.fq --input2 src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/SRR1931701.dual.barcoded_2.fq --verbosity ERROR --QUIET true  --splitByReadGroup false --splitByLibrary false --createOutputBamIndex true --createOutputBamMD5 false --maximumMismatches 0 --minimumDistance 1 --nNoMismatch false --rawBarcodeSequenceTags BC --barcodeInReadName false --secondsBetweenProgressUpdates 10.0 --readValidationStringency SILENT --interleavedInput false --help false --version false --showHidden false --use_jdk_deflater false --use_jdk_inflater false
+## htsjdk.samtools.metrics.StringHeader
+# Started on: April 7, 2017 4:24:15 PM CEST
+
+
+
 ## org.magicdgs.readtools.metrics.barcodes.BarcodeDetector
 # No match: 1	Discarded by N: 0	Discarded by mismatch: 12	Discarded by distance: 0
 
 ## METRICS CLASS	org.magicdgs.readtools.metrics.barcodes.MatcherStat
-SAMPLE	BARCODE	RECORDS
-sample1	ATTACTCG-ATAGAGGC	6
-sample2	TCCGGAGA-CCTATCCT	5
-sample3	CGCTCATT-GGCTCTGA	9
-sample4	GAGATTCC-AGGCGAAG	10
-sample5	ATTCAGAA-TAATCTTA	5
-sample6	GAATTCGT-CAGGACGT	16
-sample7	CTGAAGCT-GTACTGAC	15
-sample8	TAATGCGC-TATAGCCT	9
-sample9	CGGCTATG-ATAGAGGC	10
-sample1	TCCGCGAA-CCTATCCT	15
-UNKNOWN	UNKNOWN	3
+SAMPLE	BARCODE	RECORDS	PCT_RECORDS
+sample1	ATTACTCG-ATAGAGGC	6	5.825243
+sample2	TCCGGAGA-CCTATCCT	5	4.854369
+sample3	CGCTCATT-GGCTCTGA	9	8.737864
+sample4	GAGATTCC-AGGCGAAG	10	9.708738
+sample5	ATTCAGAA-TAATCTTA	5	4.854369
+sample6	GAATTCGT-CAGGACGT	16	15.533981
+sample7	CTGAAGCT-GTACTGAC	15	14.563107
+sample8	TAATGCGC-TATAGCCT	9	8.737864
+sample9	CGGCTATG-ATAGAGGC	10	9.708738
+sample1	TCCGCGAA-CCTATCCT	15	14.563107
+UNKNOWN	UNKNOWN	3	2.912621
 
 
 

--- a/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testPairEndDefaultParametersUniqueBarcode.metrics
+++ b/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testPairEndDefaultParametersUniqueBarcode.metrics
@@ -1,19 +1,26 @@
+## htsjdk.samtools.metrics.StringHeader
+# org.magicdgs.readtools.tools.barcodes.AssignReadGroupByBarcode  --output src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testPairEndDefaultParametersUniqueBarcode --outputFormat SAM --splitBySample false --addOutputSAMProgramRecord false --forceOverwrite true --barcodeFile src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/unique.barcodes --keepDiscarded true --input src/test/resources/org/magicdgs/readtools/data/SRR1931701_1.fq --input2 src/test/resources/org/magicdgs/readtools/data/SRR1931701_2.fq --verbosity ERROR --QUIET true  --splitByReadGroup false --splitByLibrary false --createOutputBamIndex true --createOutputBamMD5 false --maximumMismatches 0 --minimumDistance 1 --nNoMismatch false --rawBarcodeSequenceTags BC --barcodeInReadName false --secondsBetweenProgressUpdates 10.0 --readValidationStringency SILENT --interleavedInput false --help false --version false --showHidden false --use_jdk_deflater false --use_jdk_inflater false
+## htsjdk.samtools.metrics.StringHeader
+# Started on: April 7, 2017 4:24:16 PM CEST
+
+
+
 ## org.magicdgs.readtools.metrics.barcodes.BarcodeDetector
 # No match: 0	Discarded by N: 0	Discarded by mismatch: 5	Discarded by distance: 0
 
 ## METRICS CLASS	org.magicdgs.readtools.metrics.barcodes.MatcherStat
-SAMPLE	BARCODE	RECORDS
-sample1	ATTACTCG	6
-sample2	TCCGGAGA	5
-sample3	CGCTCATT	9
-sample4	GAGATTCC	9
-sample5	ATTCAGAA	5
-sample6	GAATTCGT	16
-sample7	CTGAAGCT	15
-sample8	TAATGCGC	8
-sample9	CGGCTATG	10
-sample1	TCCGCGAA	15
-UNKNOWN	UNKNOWN	5
+SAMPLE	BARCODE	RECORDS	PCT_RECORDS
+sample1	ATTACTCG	6	5.825243
+sample2	TCCGGAGA	5	4.854369
+sample3	CGCTCATT	9	8.737864
+sample4	GAGATTCC	9	8.737864
+sample5	ATTCAGAA	5	4.854369
+sample6	GAATTCGT	16	15.533981
+sample7	CTGAAGCT	15	14.563107
+sample8	TAATGCGC	8	7.76699
+sample9	CGGCTATG	10	9.708738
+sample1	TCCGCGAA	15	14.563107
+UNKNOWN	UNKNOWN	5	4.854369
 
 
 

--- a/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testPairEndMaxMismatch.metrics
+++ b/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testPairEndMaxMismatch.metrics
@@ -1,19 +1,26 @@
+## htsjdk.samtools.metrics.StringHeader
+# org.magicdgs.readtools.tools.barcodes.AssignReadGroupByBarcode  --output src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testPairEndMaxMismatch --outputFormat SAM --splitBySample false --addOutputSAMProgramRecord false --forceOverwrite true --barcodeFile src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/dual.barcodes --maximumMismatches 3 --keepDiscarded true --input src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/SRR1931701.dual.barcoded_1.fq --input2 src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/SRR1931701.dual.barcoded_2.fq --verbosity ERROR --QUIET true  --splitByReadGroup false --splitByLibrary false --createOutputBamIndex true --createOutputBamMD5 false --minimumDistance 1 --nNoMismatch false --rawBarcodeSequenceTags BC --barcodeInReadName false --secondsBetweenProgressUpdates 10.0 --readValidationStringency SILENT --interleavedInput false --help false --version false --showHidden false --use_jdk_deflater false --use_jdk_inflater false
+## htsjdk.samtools.metrics.StringHeader
+# Started on: April 7, 2017 4:24:15 PM CEST
+
+
+
 ## org.magicdgs.readtools.metrics.barcodes.BarcodeDetector
 # No match: 1	Discarded by N: 0	Discarded by mismatch: 1	Discarded by distance: 1
 
 ## METRICS CLASS	org.magicdgs.readtools.metrics.barcodes.MatcherStat
-SAMPLE	BARCODE	RECORDS
-sample1	ATTACTCG-ATAGAGGC	7
-sample2	TCCGGAGA-CCTATCCT	5
-sample3	CGCTCATT-GGCTCTGA	9
-sample4	GAGATTCC-AGGCGAAG	10
-sample5	ATTCAGAA-TAATCTTA	6
-sample6	GAATTCGT-CAGGACGT	16
-sample7	CTGAAGCT-GTACTGAC	15
-sample8	TAATGCGC-TATAGCCT	9
-sample9	CGGCTATG-ATAGAGGC	10
-sample1	TCCGCGAA-CCTATCCT	15
-UNKNOWN	UNKNOWN	1
+SAMPLE	BARCODE	RECORDS	PCT_RECORDS
+sample1	ATTACTCG-ATAGAGGC	7	6.796117
+sample2	TCCGGAGA-CCTATCCT	5	4.854369
+sample3	CGCTCATT-GGCTCTGA	9	8.737864
+sample4	GAGATTCC-AGGCGAAG	10	9.708738
+sample5	ATTCAGAA-TAATCTTA	6	5.825243
+sample6	GAATTCGT-CAGGACGT	16	15.533981
+sample7	CTGAAGCT-GTACTGAC	15	14.563107
+sample8	TAATGCGC-TATAGCCT	9	8.737864
+sample9	CGGCTATG-ATAGAGGC	10	9.708738
+sample1	TCCGCGAA-CCTATCCT	15	14.563107
+UNKNOWN	UNKNOWN	1	0.970874
 
 
 

--- a/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testSingleEndDefaultParameterUniqueBarcode.metrics
+++ b/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testSingleEndDefaultParameterUniqueBarcode.metrics
@@ -1,19 +1,26 @@
+## htsjdk.samtools.metrics.StringHeader
+# org.magicdgs.readtools.tools.barcodes.AssignReadGroupByBarcode  --output src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testSingleEndDefaultParameterUniqueBarcode --outputFormat SAM --splitBySample false --addOutputSAMProgramRecord false --forceOverwrite true --barcodeFile src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/unique.barcodes --keepDiscarded true --input src/test/resources/org/magicdgs/readtools/data/SRR1931701_1.fq --verbosity ERROR --QUIET true  --splitByReadGroup false --splitByLibrary false --createOutputBamIndex true --createOutputBamMD5 false --maximumMismatches 0 --minimumDistance 1 --nNoMismatch false --rawBarcodeSequenceTags BC --barcodeInReadName false --secondsBetweenProgressUpdates 10.0 --readValidationStringency SILENT --interleavedInput false --help false --version false --showHidden false --use_jdk_deflater false --use_jdk_inflater false
+## htsjdk.samtools.metrics.StringHeader
+# Started on: April 7, 2017 4:24:16 PM CEST
+
+
+
 ## org.magicdgs.readtools.metrics.barcodes.BarcodeDetector
 # No match: 0	Discarded by N: 0	Discarded by mismatch: 5	Discarded by distance: 0
 
 ## METRICS CLASS	org.magicdgs.readtools.metrics.barcodes.MatcherStat
-SAMPLE	BARCODE	RECORDS
-sample1	ATTACTCG	6
-sample2	TCCGGAGA	5
-sample3	CGCTCATT	9
-sample4	GAGATTCC	9
-sample5	ATTCAGAA	5
-sample6	GAATTCGT	16
-sample7	CTGAAGCT	15
-sample8	TAATGCGC	8
-sample9	CGGCTATG	10
-sample1	TCCGCGAA	15
-UNKNOWN	UNKNOWN	5
+SAMPLE	BARCODE	RECORDS	PCT_RECORDS
+sample1	ATTACTCG	6	5.825243
+sample2	TCCGGAGA	5	4.854369
+sample3	CGCTCATT	9	8.737864
+sample4	GAGATTCC	9	8.737864
+sample5	ATTCAGAA	5	4.854369
+sample6	GAATTCGT	16	15.533981
+sample7	CTGAAGCT	15	14.563107
+sample8	TAATGCGC	8	7.76699
+sample9	CGGCTATG	10	9.708738
+sample1	TCCGCGAA	15	14.563107
+UNKNOWN	UNKNOWN	5	4.854369
 
 
 

--- a/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testSingleEndDefaultParameters.metrics
+++ b/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testSingleEndDefaultParameters.metrics
@@ -1,19 +1,26 @@
+## htsjdk.samtools.metrics.StringHeader
+# org.magicdgs.readtools.tools.barcodes.AssignReadGroupByBarcode  --output src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testSingleEndDefaultParameters --outputFormat SAM --splitBySample false --addOutputSAMProgramRecord false --forceOverwrite true --barcodeFile src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/dual.barcodes --keepDiscarded true --input src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/SRR1931701.dual.barcoded_1.fq --verbosity ERROR --QUIET true  --splitByReadGroup false --splitByLibrary false --createOutputBamIndex true --createOutputBamMD5 false --maximumMismatches 0 --minimumDistance 1 --nNoMismatch false --rawBarcodeSequenceTags BC --barcodeInReadName false --secondsBetweenProgressUpdates 10.0 --readValidationStringency SILENT --interleavedInput false --help false --version false --showHidden false --use_jdk_deflater false --use_jdk_inflater false
+## htsjdk.samtools.metrics.StringHeader
+# Started on: April 7, 2017 4:24:15 PM CEST
+
+
+
 ## org.magicdgs.readtools.metrics.barcodes.BarcodeDetector
 # No match: 1	Discarded by N: 0	Discarded by mismatch: 12	Discarded by distance: 0
 
 ## METRICS CLASS	org.magicdgs.readtools.metrics.barcodes.MatcherStat
-SAMPLE	BARCODE	RECORDS
-sample1	ATTACTCG-ATAGAGGC	6
-sample2	TCCGGAGA-CCTATCCT	5
-sample3	CGCTCATT-GGCTCTGA	9
-sample4	GAGATTCC-AGGCGAAG	10
-sample5	ATTCAGAA-TAATCTTA	5
-sample6	GAATTCGT-CAGGACGT	16
-sample7	CTGAAGCT-GTACTGAC	15
-sample8	TAATGCGC-TATAGCCT	9
-sample9	CGGCTATG-ATAGAGGC	10
-sample1	TCCGCGAA-CCTATCCT	15
-UNKNOWN	UNKNOWN	3
+SAMPLE	BARCODE	RECORDS	PCT_RECORDS
+sample1	ATTACTCG-ATAGAGGC	6	5.825243
+sample2	TCCGGAGA-CCTATCCT	5	4.854369
+sample3	CGCTCATT-GGCTCTGA	9	8.737864
+sample4	GAGATTCC-AGGCGAAG	10	9.708738
+sample5	ATTCAGAA-TAATCTTA	5	4.854369
+sample6	GAATTCGT-CAGGACGT	16	15.533981
+sample7	CTGAAGCT-GTACTGAC	15	14.563107
+sample8	TAATGCGC-TATAGCCT	9	8.737864
+sample9	CGGCTATG-ATAGAGGC	10	9.708738
+sample1	TCCGCGAA-CCTATCCT	15	14.563107
+UNKNOWN	UNKNOWN	3	2.912621
 
 
 

--- a/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testSingleEndSplitting.metrics
+++ b/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testSingleEndSplitting.metrics
@@ -1,19 +1,26 @@
+## htsjdk.samtools.metrics.StringHeader
+# org.magicdgs.readtools.tools.barcodes.AssignReadGroupByBarcode  --output src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testSingleEndSplitting --outputFormat SAM --splitBySample true --addOutputSAMProgramRecord false --forceOverwrite true --barcodeFile src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/dual.barcodes --keepDiscarded true --input src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/SRR1931701.dual.barcoded_1.fq --verbosity ERROR --QUIET true  --splitByReadGroup false --splitByLibrary false --createOutputBamIndex true --createOutputBamMD5 false --maximumMismatches 0 --minimumDistance 1 --nNoMismatch false --rawBarcodeSequenceTags BC --barcodeInReadName false --secondsBetweenProgressUpdates 10.0 --readValidationStringency SILENT --interleavedInput false --help false --version false --showHidden false --use_jdk_deflater false --use_jdk_inflater false
+## htsjdk.samtools.metrics.StringHeader
+# Started on: April 7, 2017 4:24:16 PM CEST
+
+
+
 ## org.magicdgs.readtools.metrics.barcodes.BarcodeDetector
 # No match: 1	Discarded by N: 0	Discarded by mismatch: 12	Discarded by distance: 0
 
 ## METRICS CLASS	org.magicdgs.readtools.metrics.barcodes.MatcherStat
-SAMPLE	BARCODE	RECORDS
-sample1	ATTACTCG-ATAGAGGC	6
-sample2	TCCGGAGA-CCTATCCT	5
-sample3	CGCTCATT-GGCTCTGA	9
-sample4	GAGATTCC-AGGCGAAG	10
-sample5	ATTCAGAA-TAATCTTA	5
-sample6	GAATTCGT-CAGGACGT	16
-sample7	CTGAAGCT-GTACTGAC	15
-sample8	TAATGCGC-TATAGCCT	9
-sample9	CGGCTATG-ATAGAGGC	10
-sample1	TCCGCGAA-CCTATCCT	15
-UNKNOWN	UNKNOWN	3
+SAMPLE	BARCODE	RECORDS	PCT_RECORDS
+sample1	ATTACTCG-ATAGAGGC	6	5.825243
+sample2	TCCGGAGA-CCTATCCT	5	4.854369
+sample3	CGCTCATT-GGCTCTGA	9	8.737864
+sample4	GAGATTCC-AGGCGAAG	10	9.708738
+sample5	ATTCAGAA-TAATCTTA	5	4.854369
+sample6	GAATTCGT-CAGGACGT	16	15.533981
+sample7	CTGAAGCT-GTACTGAC	15	14.563107
+sample8	TAATGCGC-TATAGCCT	9	8.737864
+sample9	CGGCTATG-ATAGAGGC	10	9.708738
+sample1	TCCGCGAA-CCTATCCT	15	14.563107
+UNKNOWN	UNKNOWN	3	2.912621
 
 
 

--- a/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testTaggedSingleEndDefaultParameterUniqueBarcode.metrics
+++ b/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testTaggedSingleEndDefaultParameterUniqueBarcode.metrics
@@ -1,19 +1,26 @@
+## htsjdk.samtools.metrics.StringHeader
+# org.magicdgs.readtools.tools.barcodes.AssignReadGroupByBarcode  --output src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testTaggedSingleEndDefaultParameterUniqueBarcode --outputFormat SAM --splitBySample false --addOutputSAMProgramRecord false --forceOverwrite true --barcodeFile src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/unique.barcodes --keepDiscarded true --input src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/SRR1931701.single.tagged.sam --verbosity ERROR --QUIET true  --splitByReadGroup false --splitByLibrary false --createOutputBamIndex true --createOutputBamMD5 false --maximumMismatches 0 --minimumDistance 1 --nNoMismatch false --rawBarcodeSequenceTags BC --barcodeInReadName false --secondsBetweenProgressUpdates 10.0 --readValidationStringency SILENT --interleavedInput false --help false --version false --showHidden false --use_jdk_deflater false --use_jdk_inflater false
+## htsjdk.samtools.metrics.StringHeader
+# Started on: April 7, 2017 4:24:15 PM CEST
+
+
+
 ## org.magicdgs.readtools.metrics.barcodes.BarcodeDetector
 # No match: 0	Discarded by N: 0	Discarded by mismatch: 5	Discarded by distance: 0
 
 ## METRICS CLASS	org.magicdgs.readtools.metrics.barcodes.MatcherStat
-SAMPLE	BARCODE	RECORDS
-sample1	ATTACTCG	6
-sample2	TCCGGAGA	5
-sample3	CGCTCATT	9
-sample4	GAGATTCC	9
-sample5	ATTCAGAA	5
-sample6	GAATTCGT	16
-sample7	CTGAAGCT	15
-sample8	TAATGCGC	8
-sample9	CGGCTATG	10
-sample1	TCCGCGAA	15
-UNKNOWN	UNKNOWN	5
+SAMPLE	BARCODE	RECORDS	PCT_RECORDS
+sample1	ATTACTCG	6	5.825243
+sample2	TCCGGAGA	5	4.854369
+sample3	CGCTCATT	9	8.737864
+sample4	GAGATTCC	9	8.737864
+sample5	ATTCAGAA	5	4.854369
+sample6	GAATTCGT	16	15.533981
+sample7	CTGAAGCT	15	14.563107
+sample8	TAATGCGC	8	7.76699
+sample9	CGGCTATG	10	9.708738
+sample1	TCCGCGAA	15	14.563107
+UNKNOWN	UNKNOWN	5	4.854369
 
 
 

--- a/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testTaggedSingleEndDefaultParameters.metrics
+++ b/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testTaggedSingleEndDefaultParameters.metrics
@@ -1,19 +1,26 @@
+## htsjdk.samtools.metrics.StringHeader
+# org.magicdgs.readtools.tools.barcodes.AssignReadGroupByBarcode  --output src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testTaggedSingleEndDefaultParameters --outputFormat SAM --splitBySample false --addOutputSAMProgramRecord false --forceOverwrite true --barcodeFile src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/dual.barcodes --keepDiscarded true --rawBarcodeSequenceTags BC --rawBarcodeSequenceTags B2 --input src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/SRR1931701.single.tagged.sam --verbosity ERROR --QUIET true  --splitByReadGroup false --splitByLibrary false --createOutputBamIndex true --createOutputBamMD5 false --maximumMismatches 0 --minimumDistance 1 --nNoMismatch false --barcodeInReadName false --secondsBetweenProgressUpdates 10.0 --readValidationStringency SILENT --interleavedInput false --help false --version false --showHidden false --use_jdk_deflater false --use_jdk_inflater false
+## htsjdk.samtools.metrics.StringHeader
+# Started on: April 7, 2017 4:24:14 PM CEST
+
+
+
 ## org.magicdgs.readtools.metrics.barcodes.BarcodeDetector
 # No match: 1	Discarded by N: 0	Discarded by mismatch: 12	Discarded by distance: 0
 
 ## METRICS CLASS	org.magicdgs.readtools.metrics.barcodes.MatcherStat
-SAMPLE	BARCODE	RECORDS
-sample1	ATTACTCG-ATAGAGGC	6
-sample2	TCCGGAGA-CCTATCCT	5
-sample3	CGCTCATT-GGCTCTGA	9
-sample4	GAGATTCC-AGGCGAAG	10
-sample5	ATTCAGAA-TAATCTTA	5
-sample6	GAATTCGT-CAGGACGT	16
-sample7	CTGAAGCT-GTACTGAC	15
-sample8	TAATGCGC-TATAGCCT	9
-sample9	CGGCTATG-ATAGAGGC	10
-sample1	TCCGCGAA-CCTATCCT	15
-UNKNOWN	UNKNOWN	3
+SAMPLE	BARCODE	RECORDS	PCT_RECORDS
+sample1	ATTACTCG-ATAGAGGC	6	5.825243
+sample2	TCCGGAGA-CCTATCCT	5	4.854369
+sample3	CGCTCATT-GGCTCTGA	9	8.737864
+sample4	GAGATTCC-AGGCGAAG	10	9.708738
+sample5	ATTCAGAA-TAATCTTA	5	4.854369
+sample6	GAATTCGT-CAGGACGT	16	15.533981
+sample7	CTGAAGCT-GTACTGAC	15	14.563107
+sample8	TAATGCGC-TATAGCCT	9	8.737864
+sample9	CGGCTATG-ATAGAGGC	10	9.708738
+sample1	TCCGCGAA-CCTATCCT	15	14.563107
+UNKNOWN	UNKNOWN	3	2.912621
 
 
 

--- a/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testTaggedSingleEndSplitting.metrics
+++ b/src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testTaggedSingleEndSplitting.metrics
@@ -1,19 +1,26 @@
+## htsjdk.samtools.metrics.StringHeader
+# org.magicdgs.readtools.tools.barcodes.AssignReadGroupByBarcode  --output src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/testTaggedSingleEndSplitting --outputFormat SAM --splitBySample true --addOutputSAMProgramRecord false --forceOverwrite true --barcodeFile src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/dual.barcodes --keepDiscarded true --rawBarcodeSequenceTags BC --rawBarcodeSequenceTags B2 --input src/test/resources/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode/SRR1931701.single.tagged.sam --verbosity ERROR --QUIET true  --splitByReadGroup false --splitByLibrary false --createOutputBamIndex true --createOutputBamMD5 false --maximumMismatches 0 --minimumDistance 1 --nNoMismatch false --barcodeInReadName false --secondsBetweenProgressUpdates 10.0 --readValidationStringency SILENT --interleavedInput false --help false --version false --showHidden false --use_jdk_deflater false --use_jdk_inflater false
+## htsjdk.samtools.metrics.StringHeader
+# Started on: April 7, 2017 4:24:15 PM CEST
+
+
+
 ## org.magicdgs.readtools.metrics.barcodes.BarcodeDetector
 # No match: 1	Discarded by N: 0	Discarded by mismatch: 12	Discarded by distance: 0
 
 ## METRICS CLASS	org.magicdgs.readtools.metrics.barcodes.MatcherStat
-SAMPLE	BARCODE	RECORDS
-sample1	ATTACTCG-ATAGAGGC	6
-sample2	TCCGGAGA-CCTATCCT	5
-sample3	CGCTCATT-GGCTCTGA	9
-sample4	GAGATTCC-AGGCGAAG	10
-sample5	ATTCAGAA-TAATCTTA	5
-sample6	GAATTCGT-CAGGACGT	16
-sample7	CTGAAGCT-GTACTGAC	15
-sample8	TAATGCGC-TATAGCCT	9
-sample9	CGGCTATG-ATAGAGGC	10
-sample1	TCCGCGAA-CCTATCCT	15
-UNKNOWN	UNKNOWN	3
+SAMPLE	BARCODE	RECORDS	PCT_RECORDS
+sample1	ATTACTCG-ATAGAGGC	6	5.825243
+sample2	TCCGGAGA-CCTATCCT	5	4.854369
+sample3	CGCTCATT-GGCTCTGA	9	8.737864
+sample4	GAGATTCC-AGGCGAAG	10	9.708738
+sample5	ATTCAGAA-TAATCTTA	5	4.854369
+sample6	GAATTCGT-CAGGACGT	16	15.533981
+sample7	CTGAAGCT-GTACTGAC	15	14.563107
+sample8	TAATGCGC-TATAGCCT	9	8.737864
+sample9	CGGCTATG-ATAGAGGC	10	9.708738
+sample1	TCCGCGAA-CCTATCCT	15	14.563107
+UNKNOWN	UNKNOWN	3	2.912621
 
 
 


### PR DESCRIPTION
Several barcode metrics fixes are included in this PR:

* Remove method in BarcodeDecoder to write metrics and use instead getters for them.
* Add default header to barcode metrics (closes #116)
* Add `PCT_RECORDS` for percentage of records assigned to each barcode (closes #153)