### PR TITLE
Improve build version number and shadow tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ targetCompatibility = 1.8
 mainClassName = group + "." + rootProject.name.toLowerCase() + ".Main"
 
 // method for defining the version using the build-number from git-hash
+// TODO: this should be removed for https://github.com/magicDGS/ReadTools/issues/184
 def hashedVersion(String semVer) {
     def hashedVersion = semVer + "-" + versionDetails().gitHash
     return (gitVersion().contains("dirty")) ? hashedVersion + "-SNAPSHOT" : hashedVersion

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ startScripts {
 }
 
 group = 'org.magicdgs'
-version = '1.0.0-SNAPSHOT'
+version = hashedVersion('1.0.0')
 description = """Tools for sequencing barcoded read data (in FASTQ/BAM format)"""
 
 def developer = "Daniel Gomez-Sanchez"
@@ -34,6 +34,12 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 mainClassName = group + "." + rootProject.name.toLowerCase() + ".Main"
+
+// method for defining the version using the build-number from git-hash
+def hashedVersion(String semVer) {
+    def hashedVersion = semVer + "-" + versionDetails().gitHash
+    return (gitVersion().contains("dirty")) ? hashedVersion + "-SNAPSHOT" : hashedVersion
+}
 
 repositories {
     mavenCentral()
@@ -64,12 +70,9 @@ task wrapper(type: Wrapper) {
 }
 
 tasks.withType(Jar) {
-    def details = versionDetails()
-    def buildNumber = (gitVersion().contains("dirty")) ? details.gitHash + ".dirty" : details.gitHash;
-    def implementationVersion = project.version.replaceAll("-SNAPSHOT", "") + "_" +  buildNumber
     manifest {
         attributes 'Implementation-Title': rootProject.name,
-            'Implementation-Version': implementationVersion,
+            'Implementation-Version': project.version,
             'Main-Class': project.mainClassName
     }
 }
@@ -136,14 +139,11 @@ tasks.withType(Test) {
 
 processResources {
     def details = versionDetails()
-    // this is better for having a "dirty" marker for versions
-    def buildNumber = (gitVersion().contains("dirty")) ? details.gitHash + ".dirty" : details.gitHash;
     // get the timestamp in its format
     def date = new Date()
     def timestamp = date.format('yyyy-MM-dd HH:mm:ss')
     expand(name: project.name,
-        version: project.version.replaceAll("-SNAPSHOT", ""),
-        buildNumber: buildNumber,
+        version: project.version,
         timestamp: timestamp,
         developer: developer,
         contact: contact) 
@@ -155,9 +155,17 @@ processTestResources {
     exclude "**/org/magicdgs/readtools/**"
 }
 
+// this task is used for have a jar file that is called just as the project name
+// may be useful for uploading jar files to several places always with the same name
+// and also to point to a concrete jar file as the executable
+task currentJar(type: Copy){
+    from shadowJar
+    into new File(buildDir, "libs")
+    rename { string -> rootProject.name + ".jar"}
+}
+
 shadowJar {
     zip64 true
-    classifier = null
-    version = null
     mergeServiceFiles()
+    finalizedBy currentJar
 }

--- a/src/main/java/org/magicdgs/readtools/Main.java
+++ b/src/main/java/org/magicdgs/readtools/Main.java
@@ -68,7 +68,7 @@ public class Main extends org.broadinstitute.hellbender.Main {
     public static void main(final String[] args) {
         if (args.length == 1
                 && ("--version".equals(args[0]) || "-v".equals(args[0]))) {
-            System.out.println(ProjectProperties.getFormattedVersion());
+            System.out.println(ProjectProperties.getVersion());
             System.exit(0);
         }
         new Main().mainEntry(args);

--- a/src/main/java/org/magicdgs/readtools/ProjectProperties.java
+++ b/src/main/java/org/magicdgs/readtools/ProjectProperties.java
@@ -48,7 +48,6 @@ public class ProjectProperties {
         final Map<String, String> defaults = new HashMap<>(6);
         defaults.put("version", "UNKNOWN");
         defaults.put("name", "Program");
-        defaults.put("build", "develop"); // the build will be computed except it is in develop
         defaults.put("timestamp", "unknown");
         defaults.put("contact_person", "DGS");
         defaults.put("contact_email", "");
@@ -58,8 +57,6 @@ public class ProjectProperties {
     private static String name = null;
 
     private static String version = null;
-
-    private static String build = null;
 
     private static String timestamp = null;
 
@@ -92,18 +89,6 @@ public class ProjectProperties {
     }
 
     /**
-     * Get the build for this project
-     *
-     * @return the build String
-     */
-    public static String getBuild() {
-        if (build == null) {
-            setValue("build");
-        }
-        return build;
-    }
-
-    /**
      * Get the compilation time
      *
      * @return the timestamp
@@ -116,54 +101,6 @@ public class ProjectProperties {
     }
 
     /**
-     * Get the contact person
-     *
-     * @return the contact person
-     */
-    public static String getContactPerson() {
-        if (contactPerson == null) {
-            setValue("contact_person");
-        }
-        return contactPerson;
-    }
-
-    /**
-     * Get the contact email
-     *
-     * @return the contact email
-     */
-    public static String getContactEmail() {
-        if (contactEmail == null) {
-            setValue("contact_email");
-        }
-        return contactEmail;
-    }
-
-    /**
-     * Get the formatted version in the format v.${version}.r_${build}
-     *
-     * @return the formatted version
-     */
-    public static String getFormattedVersion() {
-        if (version == null || build == null) {
-            getAllPropertiesForProgramHeader();
-        }
-        return String.format("%s.r_%s", version, build);
-    }
-
-    /**
-     * Get the formatted name with version like Name v.${version}.r_${build}
-     *
-     * @return the formatted name with version
-     */
-    public static String getFormattedNameWithVersion() {
-        if (version == null || build == null || name == null) {
-            getAllPropertiesForProgramHeader();
-        }
-        return String.format("%s v.%s", name, getFormattedVersion());
-    }
-
-    /**
      * Get the full contact (Name + email)
      *
      * @return the full contact
@@ -173,18 +110,6 @@ public class ProjectProperties {
             getAllPropertiesForProgramHeader();
         }
         return String.format("%s (%s)", contactPerson, contactEmail);
-    }
-
-    /**
-     * Get the operating system where the program is running as ${os.name} ${os.version}
-     * (${os.arch})
-     *
-     * @return the formatted string
-     */
-    public static String getOperatingSystem() {
-        return String.format("%s %s (%s)", System.getProperty("os.name"),
-                System.getProperty("os.version"),
-                System.getProperty("os.arch"));
     }
 
     /**
@@ -268,9 +193,6 @@ public class ProjectProperties {
         switch (tag) {
             case "name":
                 name = val;
-                break;
-            case "build":
-                build = val;
                 break;
             case "timestamp":
                 timestamp = val;

--- a/src/main/resources/version.prop
+++ b/src/main/resources/version.prop
@@ -1,6 +1,5 @@
 name=${name}
 version=${version}
-build=${buildNumber}
 timestamp=${timestamp}
 contact_person=${developer}
 contact_email=${contact}


### PR DESCRIPTION
* Dirty versions are SNAPSHOT
* Non-dirty versions are not SNAPSHOT
* Version includes the git hash always
* Uber-jar classifier and version are the defaults
* New task for obtaining the current uber-jar without prefixes
* Rermove buildNumber from version properties
* Clean-up the ProjectProperties class