### PR TITLE
Update HTSJDK to 2.9.1-28-g909ac4d

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ repositories {
 }
 // versions for the dependencies
 final gatkVersion = '4.alpha.2-221-g2ecdef4-SNAPSHOT' // TODO: we should use the master-SNAPSHOT one is done (gatk/issue#1995)
-final htsjdkVersion = '2.9.1-9-g6d22658-SNAPSHOT' // TODO: bring back to the HTSJDK release
+final htsjdkVersion = '2.9.1-28-g909ac4d-SNAPSHOT' // TODO: bring back to the HTSJDK release
 
 dependencies {
     compile (group: 'org.broadinstitute', name: 'gatk', version: gatkVersion) {


### PR DESCRIPTION
This version contains more informative error message while parsing FASTQ
files, and when converting char to bases.