### PR TITLE
Extract ReadToolsProgram for all the tools

### DIFF
--- a/src/main/java/org/magicdgs/readtools/engine/ReadToolsProgram.java
+++ b/src/main/java/org/magicdgs/readtools/engine/ReadToolsProgram.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.magicdgs.readtools.engine;
+
+import org.magicdgs.readtools.RTHelpConstants;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMProgramRecord;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
+
+/**
+ * Abstract class for all the ReadTools programs.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public abstract class ReadToolsProgram extends CommandLineProgram {
+
+    /**
+     * Returns a program tag to the header with a program version {@link #getVersion()}, program
+     * name {@link #getToolName()} and command line {@link #getCommandLine()}.
+     *
+     * @param header the header to get an unique program group ID.
+     *
+     * @return the program record.
+     */
+    protected final SAMProgramRecord getProgramRecord(final SAMFileHeader header) {
+        final SAMProgramRecord programRecord = new SAMProgramRecord(createProgramGroupID(header));
+        programRecord.setProgramVersion(getVersion());
+        programRecord.setCommandLine(getCommandLine());
+        programRecord.setProgramName(getToolName());
+        return programRecord;
+    }
+
+    /**
+     * Returns the program group ID that will be used in the SAM writer.
+     * Starts with {@link #getToolName} and looks for the first available ID by appending
+     * consecutive integers.
+     */
+    private final String createProgramGroupID(final SAMFileHeader header) {
+        final String toolName = getToolName();
+
+        String pgID = toolName;
+        SAMProgramRecord record = header.getProgramRecord(pgID);
+        int count = 1;
+        while (record != null) {
+            pgID = toolName + "." + String.valueOf(count++);
+            record = header.getProgramRecord(pgID);
+        }
+        return pgID;
+    }
+
+    /**
+     * Returns the name of this tool, which is the combination of
+     * {@link RTHelpConstants#PROGRAM_NAME} and the simple class name.
+     */
+    public final String getToolName() {
+        return RTHelpConstants.PROGRAM_NAME + " " + getClass().getSimpleName();
+    }
+}

--- a/src/main/java/org/magicdgs/readtools/engine/ReadToolsWalker.java
+++ b/src/main/java/org/magicdgs/readtools/engine/ReadToolsWalker.java
@@ -56,7 +56,7 @@ import java.util.stream.StreamSupport;
  *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public abstract class ReadToolsWalker extends CommandLineProgram {
+public abstract class ReadToolsWalker extends ReadToolsProgram {
 
     // For the progress meter in the GATKTool
     @Argument(fullName = GATKTool.SECONDS_BETWEEN_PROGRESS_UPDATES_NAME, shortName = GATKTool.SECONDS_BETWEEN_PROGRESS_UPDATES_NAME, doc = "Output traversal statistics every time this many seconds elapse.", optional = true, common = true)
@@ -73,7 +73,7 @@ public abstract class ReadToolsWalker extends CommandLineProgram {
      * {@link ProgressMeter#update(Locatable)} after each record processed from
      * the primary input in their {@link #traverse} method.
      */
-    // TODO: probably our progress metter could be better
+    // TODO: probably our own progress meter could be better
     // TODO: because this only takes into account the locus positions
     private ProgressMeter progressMeter;
 
@@ -236,52 +236,6 @@ public abstract class ReadToolsWalker extends CommandLineProgram {
      */
     public final SAMFileHeader getHeaderForReads() {
         return dataSource.getHeader();
-    }
-
-    /**
-     * Returns a program tag to the header with a program version {@link #getVersion()}, program
-     * name {@link #getToolName()} and command line {@link #getCommandLine()}.
-     *
-     * Subclasses may override.
-     *
-     * @param header the header to get an unique program group ID.
-     *
-     * @return the program record.
-     */
-    protected SAMProgramRecord getProgramRecord(final SAMFileHeader header) {
-        final SAMProgramRecord programRecord = new SAMProgramRecord(createProgramGroupID(header));
-        programRecord.setProgramVersion(getVersion());
-        programRecord.setCommandLine(getCommandLine());
-        programRecord.setProgramName(getToolName());
-        return programRecord;
-    }
-
-    /**
-     * Returns the program group ID that will be used in the SAM writer.
-     * Starts with {@link #getToolName} and looks for the first available ID by appending
-     * consecutive integers.
-     */
-    private String createProgramGroupID(final SAMFileHeader header) {
-        final String toolName = getToolName();
-
-        String pgID = toolName;
-        SAMProgramRecord record = header.getProgramRecord(pgID);
-        int count = 1;
-        while (record != null) {
-            pgID = toolName + "." + String.valueOf(count++);
-            record = header.getProgramRecord(pgID);
-        }
-        return pgID;
-    }
-
-    /**
-     * Returns the name of this GATK tool.
-     * The default implementation return the the string "GATK " followed by the simple name of the
-     * class.
-     * Subclasses may override.
-     */
-    public String getToolName() {
-        return RTHelpConstants.PROGRAM_NAME + " " + getClass().getSimpleName();
     }
 
 }

--- a/src/main/java/org/magicdgs/readtools/engine/ReadToolsWalker.java
+++ b/src/main/java/org/magicdgs/readtools/engine/ReadToolsWalker.java
@@ -24,16 +24,13 @@
 
 package org.magicdgs.readtools.engine;
 
-import org.magicdgs.readtools.RTHelpConstants;
 import org.magicdgs.readtools.cmd.argumentcollections.RTInputArgumentCollection;
 
 import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.SAMProgramRecord;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.Locatable;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
-import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.GATKTool;
 import org.broadinstitute.hellbender.engine.ProgressMeter;

--- a/src/main/java/org/magicdgs/readtools/tools/quality/QualityEncodingDetector.java
+++ b/src/main/java/org/magicdgs/readtools/tools/quality/QualityEncodingDetector.java
@@ -32,7 +32,6 @@ import org.magicdgs.readtools.utils.read.ReadReaderFactory;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
-import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.QCProgramGroup;
 

--- a/src/main/java/org/magicdgs/readtools/tools/quality/QualityEncodingDetector.java
+++ b/src/main/java/org/magicdgs/readtools/tools/quality/QualityEncodingDetector.java
@@ -25,6 +25,7 @@
 package org.magicdgs.readtools.tools.quality;
 
 import org.magicdgs.readtools.RTDefaults;
+import org.magicdgs.readtools.engine.ReadToolsProgram;
 import org.magicdgs.readtools.engine.sourcehandler.ReadsSourceHandler;
 import org.magicdgs.readtools.utils.read.ReadReaderFactory;
 
@@ -43,7 +44,7 @@ import java.io.IOException;
 @CommandLineProgramProperties(oneLineSummary = "Detects the quality encoding format for all kind of sources for ReadTools.",
         summary = "Detects the quality encoding for a SAM/BAM/CRAM/FASTQ files, output to the STDOUT the quality encoding.",
         programGroup = QCProgramGroup.class)
-public final class QualityEncodingDetector extends CommandLineProgram {
+public final class QualityEncodingDetector extends ReadToolsProgram {
 
     @Argument(fullName = StandardArgumentDefinitions.INPUT_LONG_NAME, shortName = StandardArgumentDefinitions.INPUT_SHORT_NAME, doc = "Reads input.", optional = false, common = true)
     public String sourceString;

--- a/src/test/java/org/magicdgs/readtools/engine/ReadToolsProgramUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/engine/ReadToolsProgramUnitTest.java
@@ -24,54 +24,44 @@
 
 package org.magicdgs.readtools.engine;
 
-import org.magicdgs.readtools.RTCommandLineProgramTest;
+import static org.testng.Assert.*;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMProgramRecord;
-import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.mockito.Mockito;
 import org.testng.Assert;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class ReadToolsWalkerUnitTest extends RTCommandLineProgramTest {
+public class ReadToolsProgramUnitTest {
 
-    // test class
-    private static class TestWalker extends ReadToolsWalker {
-        private int nReads = 0;
-
+    private static class TestProgram extends ReadToolsProgram {
         @Override
-        protected void apply(GATKRead read) {
-            nReads++;
+        protected Object doWork() {
+            return null;
         }
-
     }
 
-    private String getTestFileName(final String fileName) {
-        return getTestFile(fileName).getAbsolutePath();
-    }
+    @Test
+    public void testGetProgramRecord() {
+        final ReadToolsProgram program = new TestProgram();
+        final String programName = "ReadTools TestProgram";
 
-    @DataProvider(name = "arguments")
-    public Object[][] walkerArguments() {
-        return new Object[][] {
-                {Arrays.asList("-I", getTestFileName("small.mapped.bam")), 206, false},
-                {Arrays.asList("-I", getTestFileName("small_1.illumina.fq"),
-                        "-I2", getTestFileName("small_2.illumina.fq")), 10, true}
-        };
-    }
+        // test the program record for an empty header
+        final SAMFileHeader header = new SAMFileHeader();
+        SAMProgramRecord pg0 = program.getProgramRecord(header);
+        Assert.assertEquals(pg0.getId(), programName);
+        Assert.assertEquals(pg0.getProgramName(), programName);
 
-    @Test(dataProvider = "arguments")
-    public void testReadToolsSimpleWalker(final List<String> args, final int expectedReads,
-            final boolean isPaired) throws Exception {
-        final TestWalker walker = new TestWalker();
-        Assert.assertNull(walker.instanceMain(injectDefaultVerbosity(args).toArray(new String[0])));
-        Assert.assertEquals(walker.isPaired(), isPaired);
-        Assert.assertEquals(walker.nReads, expectedReads);
+        // test adding more program records
+        for (int i = 1; i < 5; i++) {
+            header.addProgramRecord(pg0);
+            pg0 = program.getProgramRecord(header);
+            Assert.assertEquals(pg0.getId(), programName + "." + i);
+            Assert.assertEquals(pg0.getProgramName(), programName);
+        }
     }
 
 }

--- a/src/test/java/org/magicdgs/readtools/engine/ReadToolsProgramUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/engine/ReadToolsProgramUnitTest.java
@@ -24,11 +24,8 @@
 
 package org.magicdgs.readtools.engine;
 
-import static org.testng.Assert.*;
-
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMProgramRecord;
-import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/src/test/java/org/magicdgs/readtools/engine/ReadToolsWalkerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/engine/ReadToolsWalkerUnitTest.java
@@ -26,8 +26,6 @@ package org.magicdgs.readtools.engine;
 
 import org.magicdgs.readtools.RTCommandLineProgramTest;
 
-import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.SAMProgramRecord;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;


### PR DESCRIPTION
This is required to extract common methods in no ReadToolsWalkers and
reuse them. In addition, this commit fix the javadoc for this methods.

- ReadToolsProgram contains useful method from ReadToolsWalker for all
  the programs
- ReadToolsWalker extend ReadToolsProgram
- QualityEncodingDetector enforced to be a ReadToolsProgram