### PR TITLE
Add RTOutputArgumentCollection.validateUserOutput()

### DIFF
--- a/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTAbstractOutputBamArgumentCollection.java
+++ b/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTAbstractOutputBamArgumentCollection.java
@@ -24,7 +24,9 @@
 
 package org.magicdgs.readtools.cmd.argumentcollections;
 
+import org.magicdgs.readtools.exceptions.RTUserExceptions;
 import org.magicdgs.readtools.utils.read.ReadWriterFactory;
+import org.magicdgs.readtools.utils.read.writer.ReadToolsIOFormat;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMProgramRecord;
@@ -57,6 +59,16 @@ abstract class RTAbstractOutputBamArgumentCollection extends RTOutputArgumentCol
                 .setForceOverwrite(forceOverwrite)
                 .setCreateIndex(createOutputBamIndex)
                 .setCreateMd5File(createOutputBamMD5);
+    }
+
+    /**
+     * Check if {@param outputName} corresponds to a BAM/SAM/CRAM file; if not, throws a
+     */
+    protected final void validateUserOutput(final String outputName) {
+        if (!ReadToolsIOFormat.isSamBamOrCram(outputName)) {
+            throw new RTUserExceptions.InvalidOutputFormat(outputName,
+                    ReadToolsIOFormat.BamFormat.values());
+        }
     }
 
     /**

--- a/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputArgumentCollection.java
+++ b/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputArgumentCollection.java
@@ -70,17 +70,24 @@ public abstract class RTOutputArgumentCollection implements Serializable {
     /**
      * Gets the output writer for the arguments.
      *
+     * Note: it uses {@link #validateUserOutput()} to assess that the output parameter is valid
+     * before creation.
+     *
      * @param header        the header for the output file.
      * @param programRecord program record supplier. May be {@code null}, but should not return
      *                      {@code null}.
      * @param presorted     if {@code true}, the output is assumed to be pre-sorted.
      * @param referenceFile the reference file for CRAM output. May be {@code null}.
+     *
+     * @throws org.broadinstitute.hellbender.exceptions.UserException if the output could not be
+     *                                                                created.
      */
     public final GATKReadWriter outputWriter(final SAMFileHeader header,
             final Supplier<SAMProgramRecord> programRecord, final boolean presorted,
             final File referenceFile) {
         Utils.nonNull(header, "null header");
         updateHeader(header, programRecord);
+        validateUserOutput();
         return createWriter(getWriterFactory().setReferenceFile(referenceFile),
                 header, presorted);
     }
@@ -93,6 +100,14 @@ public abstract class RTOutputArgumentCollection implements Serializable {
      * used.
      */
     public abstract Path makeMetricsFile(final String suffix);
+
+    /**
+     * Validates the user output of the
+     *
+     * @throws org.broadinstitute.hellbender.exceptions.UserException if the user output is not
+     *                                                                valid.
+     */
+    public abstract void validateUserOutput();
 
     /**
      * Creates the writer with the provided factory, updated header and presorted.

--- a/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputBamArgumentCollection.java
+++ b/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputBamArgumentCollection.java
@@ -24,7 +24,6 @@
 
 package org.magicdgs.readtools.cmd.argumentcollections;
 
-import org.magicdgs.readtools.exceptions.RTUserExceptions;
 import org.magicdgs.readtools.utils.read.writer.ReadToolsIOFormat;
 import org.magicdgs.readtools.utils.read.ReadWriterFactory;
 
@@ -51,10 +50,7 @@ class RTOutputBamArgumentCollection extends RTAbstractOutputBamArgumentCollectio
     public String getOutputNameWithSuffix(final String suffix) {
         final String outputNameWithSuffix = FilenameUtils.removeExtension(outputName) + suffix
                 + "." + FilenameUtils.getExtension(outputName);
-        if (!ReadToolsIOFormat.isSamBamOrCram(outputNameWithSuffix)) {
-            throw new RTUserExceptions.InvalidOutputFormat(outputNameWithSuffix,
-                    ReadToolsIOFormat.BamFormat.values());
-        }
+        validateUserOutput(outputNameWithSuffix);
         return outputNameWithSuffix;
     }
 
@@ -67,6 +63,11 @@ class RTOutputBamArgumentCollection extends RTAbstractOutputBamArgumentCollectio
         return ReadToolsIOFormat.makeMetricsFile(prefix);
     }
 
+    @Override
+    public void validateUserOutput() {
+        validateUserOutput(outputName);
+    }
+
     /**
      * Checks if the output name is a SAM/BAM/CRAM file and if so it creates a SAM writer.
      * Otherwise, it thrown an UserException.
@@ -74,10 +75,7 @@ class RTOutputBamArgumentCollection extends RTAbstractOutputBamArgumentCollectio
     @Override
     protected GATKReadWriter createWriter(final ReadWriterFactory factory,
             final SAMFileHeader header, final boolean presorted) {
-        if (!ReadToolsIOFormat.isSamBamOrCram(outputName)) {
-            throw new RTUserExceptions.InvalidOutputFormat(outputName,
-                    ReadToolsIOFormat.BamFormat.values());
-        }
+        validateUserOutput();
         return factory.createSAMWriter(outputName, header, presorted);
     }
 }

--- a/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputBamSplitArgumentCollection.java
+++ b/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputBamSplitArgumentCollection.java
@@ -79,6 +79,11 @@ class RTOutputBamSplitArgumentCollection extends RTAbstractOutputBamArgumentColl
     }
 
     @Override
+    public void validateUserOutput() {
+        // do nothing, because the extension is always valid the outputFormat
+    }
+
+    @Override
     protected GATKReadWriter createWriter(final ReadWriterFactory factory,
             final SAMFileHeader header, final boolean presorted) {
         // set the splitter

--- a/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputFastqArgumentCollection.java
+++ b/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputFastqArgumentCollection.java
@@ -84,6 +84,11 @@ final class RTOutputFastqArgumentCollection extends RTOutputArgumentCollection {
     }
 
     @Override
+    public void validateUserOutput() {
+        // do nothing because the output suffix comes always from the outputFormat
+    }
+
+    @Override
     protected void updateHeader(final SAMFileHeader header,
             final Supplier<SAMProgramRecord> programRecord) {
         // do nothing!


### PR DESCRIPTION
This is useful for testing correctness of output format before processing (if required). Only useful for SAM/BAM/CRAM single files, but it may have more usages.