### PR TITLE
Implement Barclay documentation framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     - TYPE=shadow
     ## test runs all the unit/integration tests
     - TYPE=test
-    ## test the documentation (javadoc task and jekyll documentation)
+    ## test the documentation (javadoc/readtoolsDoc tasks and jekyll documentation)
     - TYPE=documentation
     global:
     # disable gradle daemon
@@ -43,7 +43,7 @@ script:
       elif [[ $TYPE == documentation ]]; then
           rvm use 2.4.0 --install --binary --fuzzy;
           bundle install --gemfile docs/Gemfile;
-          ./gradlew javadoc;
+          ./gradlew javadoc readtoolsDoc;
           ./scripts/test_documentation.sh;
       else
           echo "Test type not recognized $TYPE";

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import javax.tools.ToolProvider
+import java.nio.file.Files
 
 // Dependencies for the buildscript (not the program)
 buildscript {
@@ -227,4 +228,9 @@ task readtoolsDoc(type: Javadoc, dependsOn: [classes]) {
     options.addStringOption("absolute-version", getVersion())
     options.addStringOption("build-timestamp", new Date().format("dd-mm-yyyy hh:mm:ss"))
     options.addStringOption("verbose")
+
+    // TODO: remove once teh index file extension is available in yml
+    doLast {
+        new File(readtoolsDocDir, "index.md").renameTo(new File(readtoolsDocDir, "index.yml"))
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import javax.tools.ToolProvider
+
 // Dependencies for the buildscript (not the program)
 buildscript {
     repositories {
@@ -37,6 +39,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 mainClassName = group + "." + rootProject.name.toLowerCase() + ".Main"
+String documentationPackage = group + "." + rootProject.name.toLowerCase() + ".documentation";
 
 repositories {
     mavenCentral()
@@ -47,6 +50,11 @@ repositories {
 // versions for the dependencies
 final gatkVersion = '4.alpha.2-266-g48006e4-SNAPSHOT' // TODO: we should use the master-SNAPSHOT one is done (gatk/issue#1995)
 final htsjdkVersion = '2.9.1-30-gdd78f77-SNAPSHOT' // TODO: bring back to the HTSJDK release
+
+// Get the jdk files we need to run javaDoc. We need to use these during compile, testCompile,
+// test execution, and readtoolsDoc generation, but we don't want them as part of the runtime
+// classpath and we don't want to redistribute them in the uber jar.
+final javadocJDKFiles = files(((URLClassLoader) ToolProvider.getSystemToolClassLoader()).getURLs())
 
 dependencies {
     compile (group: 'org.broadinstitute', name: 'gatk', version: gatkVersion) {
@@ -59,6 +67,10 @@ dependencies {
     // compilation for testing
     testCompile 'org.testng:testng:6.11'
     testCompile 'org.mockito:mockito-core:2.7.19'
+
+    // javadoc utilities; compile/test only to prevent redistribution of sdk jars
+    compileOnly(javadocJDKFiles)
+    testCompile(javadocJDKFiles)
 }
 
 // for managing the wrapper task
@@ -154,4 +166,45 @@ shadowJar {
     zip64 true
     mergeServiceFiles()
     finalizedBy currentJar
+}
+
+// Generate ReadTools Online Doc files (jekyll formatted)
+task readtoolsDoc(type: Javadoc, dependsOn: ['cleanReadtoolsDoc', classes]) {
+    // directories
+    final File readtoolsDocDir = new File(buildDir, "docs/readtools")
+    final String readtoolsTemplates = "src/main/resources/" + documentationPackage.replaceAll("\\.", "/")
+
+    doFirst {
+        // make sure the output folder exists or we can create it
+        if (!readtoolsDocDir.exists() && !readtoolsDocDir.mkdirs()) {
+            throw new GradleException(String.format("Failure creating folder (%s) for ReadTools doc output in task (%s)",
+                    readtoolsDocDir.getAbsolutePath(),
+                    it.name));
+        }
+        final File templatesDir = new File(readtoolsTemplates);
+        if (! templatesDir.exists()) {
+            throw new GradleException(String.format("Templates folder (%s) for ReadTools doc input does not exists in task (%s)",
+                    templatesDir.getAbsolutePath(),
+                    it.name));
+        }
+    }
+
+    source = sourceSets.main.allJava
+
+    // The readtoolsDoc process instantiates any documented feature classes, so to run it we need the entire
+    // runtime classpath, as well as jdk javadoc files such as tools.jar, where com.sun.javadoc lives.
+    classpath = sourceSets.main.runtimeClasspath + javadocJDKFiles
+    options.docletpath = classpath.asType(List)
+    options.doclet = documentationPackage + ".RTHelpDoclet"
+
+    outputs.dir(readtoolsDocDir)
+    options.destinationDirectory(readtoolsDocDir)
+
+
+    options.addStringOption("settings-dir", readtoolsTemplates)
+    // TODO: output in markdown format
+    options.addStringOption("output-file-extension", "md")
+    options.addStringOption("absolute-version", getVersion())
+    options.addStringOption("build-timestamp", new Date().format("dd-mm-yyyy hh:mm:ss"))
+    options.addStringOption("verbose")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -169,7 +169,7 @@ shadowJar {
 }
 
 // Generate ReadTools Online Doc files (jekyll formatted)
-task readtoolsDoc(type: Javadoc, dependsOn: ['cleanReadtoolsDoc', classes]) {
+task readtoolsDoc(type: Javadoc, dependsOn: [classes]) {
     // directories
     final File readtoolsDocDir = new File(buildDir, "docs/readtools")
     final String readtoolsTemplates = "src/main/resources/" + documentationPackage.replaceAll("\\.", "/")
@@ -189,6 +189,7 @@ task readtoolsDoc(type: Javadoc, dependsOn: ['cleanReadtoolsDoc', classes]) {
         }
     }
 
+    // TODO: include GATK sources (only filters and plugins are required now)
     source = sourceSets.main.allJava
 
     // The readtoolsDoc process instantiates any documented feature classes, so to run it we need the entire
@@ -202,7 +203,8 @@ task readtoolsDoc(type: Javadoc, dependsOn: ['cleanReadtoolsDoc', classes]) {
 
 
     options.addStringOption("settings-dir", readtoolsTemplates)
-    // TODO: output in markdown format
+    // TODO: add index-file-extension yml option (requires https://github.com/broadinstitute/barclay/pull/60)
+    // TODO: see https://github.com/magicDGS/ReadTools/issues/243
     options.addStringOption("output-file-extension", "md")
     options.addStringOption("absolute-version", getVersion())
     options.addStringOption("build-timestamp", new Date().format("dd-mm-yyyy hh:mm:ss"))

--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,16 @@ final htsjdkVersion = '2.9.1-30-gdd78f77-SNAPSHOT' // TODO: bring back to the HT
 // classpath and we don't want to redistribute them in the uber jar.
 final javadocJDKFiles = files(((URLClassLoader) ToolProvider.getSystemToolClassLoader()).getURLs())
 
+configurations {
+    doc {
+        transitive false
+    }
+}
+
 dependencies {
-    compile (group: 'org.broadinstitute', name: 'gatk', version: gatkVersion) {
+    // use the same GATK dependency for compile and documentation
+    final gatkDependency = 'org.broadinstitute:gatk:' + gatkVersion
+    compile (gatkDependency) {
         exclude module: 'jgrapht' // this is not required
         exclude module: 'htsjdk'
         exclude module: 'testng'
@@ -71,6 +79,8 @@ dependencies {
     // javadoc utilities; compile/test only to prevent redistribution of sdk jars
     compileOnly(javadocJDKFiles)
     testCompile(javadocJDKFiles)
+
+    doc gatkDependency
 }
 
 // for managing the wrapper task
@@ -189,8 +199,15 @@ task readtoolsDoc(type: Javadoc, dependsOn: [classes]) {
         }
     }
 
-    // TODO: include GATK sources (only filters and plugins are required now)
-    source = sourceSets.main.allJava
+    // Add all the doc sources and the main ones
+    final docSources = configurations.doc.collect { zipTree(it) }
+    source = files(docSources) + sourceSets.main.allJava
+
+    // exclude test
+    exclude '**/test/**'
+    // include all our classes, and the GATK engine and command line, which contain plugins and filters
+    // TODO: we should document the GATK tools included in our framework
+    include '**/readtools/**', '**/hellbender/engine/**', '**/cmdline/**'
 
     // The readtoolsDoc process instantiates any documented feature classes, so to run it we need the entire
     // runtime classpath, as well as jdk javadoc files such as tools.jar, where com.sun.javadoc lives.
@@ -203,8 +220,8 @@ task readtoolsDoc(type: Javadoc, dependsOn: [classes]) {
 
 
     options.addStringOption("settings-dir", readtoolsTemplates)
-    // TODO: add index-file-extension yml option (requires https://github.com/broadinstitute/barclay/pull/60)
-    // TODO: see https://github.com/magicDGS/ReadTools/issues/243
+    // TODO: uncomment the next line (https://github.com/magicDGS/ReadTools/issues/243) -> requires https://github.com/broadinstitute/barclay/pull/60
+    // options.addStringOption("index-file-extension", "yml")
     options.addStringOption("output-file-extension", "md")
     options.addStringOption("absolute-version", getVersion())
     options.addStringOption("build-timestamp", new Date().format("dd-mm-yyyy hh:mm:ss"))

--- a/build.gradle
+++ b/build.gradle
@@ -229,7 +229,7 @@ task readtoolsDoc(type: Javadoc, dependsOn: [classes]) {
     options.addStringOption("build-timestamp", new Date().format("dd-mm-yyyy hh:mm:ss"))
     options.addStringOption("verbose")
 
-    // TODO: remove once teh index file extension is available in yml
+    // TODO: remove once the index file extension is available in yml -> requires https://github.com/magicDGS/ReadTools/issues/243
     doLast {
         new File(readtoolsDocDir, "index.md").renameTo(new File(readtoolsDocDir, "index.yml"))
     }

--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,8 @@ dependencies {
     compileOnly(javadocJDKFiles)
     testCompile(javadocJDKFiles)
 
-    doc gatkDependency
+    // requires sources from GATK for the documentation
+    doc gatkDependency + ":sources"
 }
 
 // for managing the wrapper task

--- a/src/main/java/org/magicdgs/readtools/RTHelpConstants.java
+++ b/src/main/java/org/magicdgs/readtools/RTHelpConstants.java
@@ -102,8 +102,9 @@ public final class RTHelpConstants {
             // include GATK's tool definitions
             groupToSuperCategory.put(HelpConstants.DOC_CAT_QC, DOC_SUPERCAT_TOOLS);
 
-            // supercat Trimmers
+            // supercat utilities (trimmers and filters)
             groupToSuperCategory.put(DOC_CAT_TRIMMERS, DOC_SUPERCAT_UTILITIES);
+            groupToSuperCategory.put(HelpConstants.DOC_CAT_READFILTERS, DOC_SUPERCAT_UTILITIES);
         }
         return groupToSuperCategory;
     }

--- a/src/main/java/org/magicdgs/readtools/RTHelpConstants.java
+++ b/src/main/java/org/magicdgs/readtools/RTHelpConstants.java
@@ -24,6 +24,11 @@
 
 package org.magicdgs.readtools;
 
+import org.broadinstitute.hellbender.utils.help.HelpConstants;
+
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Constants for help/documentation purposes.
  *
@@ -46,21 +51,67 @@ public final class RTHelpConstants {
     /** Documentation main page. */
     public static final String DOCUMENTATION_PAGE = "http://magicdgs.github.io/ReadTools/";
 
-    ///////////////////////////////
-    // PROGRAM GROUP NAMES
+    //////////////////////////////////////////////////
+    // PROGRAM GROUP NAMES AND DESCRIPTIONS FOR TOOLS
+
+    /** Supercategory for tools */
+    private final static String DOC_SUPERCAT_TOOLS = "tools";
 
     /** Documentation name for reads manipulation. */
     public static final String DOC_CAT_READS_MANIPULATION = "Reads manipulation";
     /** Documentation description for reads manipulation. */
-    public static final String DOC_CAT_READS_MANIPULATION_SUMMARY = "Tools for manipulating any supported read source (SAM/BAM/CRAM/FASTQ)";
+    public static final String DOC_CAT_READS_MANIPULATION_SUMMARY =
+            "Tools for manipulating any supported read source (SAM/BAM/CRAM/FASTQ)";
 
     /** Documentation name for reads conversion. */
     public static final String DOC_CAT_READS_CONVERSION = "Reads conversion";
     /** Documentation description for reads conversion. */
-    public static final String DOC_CAT_READS_CONVERSION_SUMMARY = "Tools for converting any supported read source (SAM/BAM/CRAM/FASTQ)";
+    public static final String DOC_CAT_READS_CONVERSION_SUMMARY =
+            "Tools for converting any supported read source (SAM/BAM/CRAM/FASTQ)";
 
-    /** Documentation name for Dismtap integration.*/
+    /** Documentation name for Dismtap integration. */
     public static final String DOC_CAT_DISTMAP = "Distmap integration";
     /** Documentation description for Distmap integration. */
-    public static final String DOC_CAT_DISTMAP_SUMMARY = "Tools for integration with the DistMap (Pandey & Schlötterer 2013).";
+    public static final String DOC_CAT_DISTMAP_SUMMARY =
+            "Tools for integration with the DistMap (Pandey & Schlötterer 2013).";
+
+    ///////////////////////////////
+    // DOCUMENTATION FOR UTILITIES
+
+    /** Supercategory for utilities. */
+    private final static String DOC_SUPERCAT_UTILITIES = "utilities";
+
+    /** Documentation name for Trimmer 'utilities'. */
+    public static final String DOC_CAT_TRIMMERS = "Trimmers";
+    public static final String DOC_CAT_TRIMMERS_SUMMARY = "Algorithms used to trim the reads.";
+
+    // map each group name to a super-category
+    private static Map<String, String> groupToSuperCategory;
+    // initialize on demand the mapping between supercategories and group names
+    private static Map<String, String> getSuperCategoryMap() {
+        if (groupToSuperCategory == null) {
+            // TODO: initialize with GATK's and/or Picard's supercat map
+
+            // do this only on demand since we only need it during docgen
+            groupToSuperCategory = new HashMap<>();
+
+            // supercat Tools
+            groupToSuperCategory.put(DOC_CAT_READS_MANIPULATION, DOC_SUPERCAT_TOOLS);
+            groupToSuperCategory.put(DOC_CAT_READS_CONVERSION, DOC_SUPERCAT_TOOLS);
+            groupToSuperCategory.put(DOC_CAT_DISTMAP, DOC_SUPERCAT_TOOLS);
+            // include GATK's tool definitions
+            groupToSuperCategory.put(HelpConstants.DOC_CAT_QC, DOC_SUPERCAT_TOOLS);
+
+            // supercat Trimmers
+            groupToSuperCategory.put(DOC_CAT_TRIMMERS, DOC_SUPERCAT_UTILITIES);
+        }
+        return groupToSuperCategory;
+    }
+
+    /** Supercategory not defined in the map. */
+    private static final String DOC_SUPERCAT_OTHER = "other";
+
+    public static String getSuperCategoryProperty(final String groupName) {
+        return getSuperCategoryMap().getOrDefault(groupName, DOC_SUPERCAT_OTHER);
+    }
 }

--- a/src/main/java/org/magicdgs/readtools/RTHelpConstants.java
+++ b/src/main/java/org/magicdgs/readtools/RTHelpConstants.java
@@ -87,11 +87,11 @@ public final class RTHelpConstants {
 
     // map each group name to a super-category
     private static Map<String, String> groupToSuperCategory;
+
     // initialize on demand the mapping between supercategories and group names
     private static Map<String, String> getSuperCategoryMap() {
         if (groupToSuperCategory == null) {
             // TODO: initialize with GATK's and/or Picard's supercat map
-
             // do this only on demand since we only need it during docgen
             groupToSuperCategory = new HashMap<>();
 
@@ -112,6 +112,10 @@ public final class RTHelpConstants {
     /** Supercategory not defined in the map. */
     private static final String DOC_SUPERCAT_OTHER = "other";
 
+    /**
+     * Returns the super-category for the group name; if not defined, the supercategory is {@link
+     * #DOC_SUPERCAT_OTHER}
+     */
     public static String getSuperCategoryProperty(final String groupName) {
         return getSuperCategoryMap().getOrDefault(groupName, DOC_SUPERCAT_OTHER);
     }

--- a/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/FixBarcodeAbstractArgumentCollection.java
+++ b/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/FixBarcodeAbstractArgumentCollection.java
@@ -179,7 +179,7 @@ public abstract class FixBarcodeAbstractArgumentCollection implements Serializab
 
 
     /** Implementation without barcode qualities. */
-    private static final class FixSimpleBarcodeArgumentCollection
+    protected static final class FixSimpleBarcodeArgumentCollection
             extends FixBarcodeAbstractArgumentCollection {
 
         @Override
@@ -190,7 +190,7 @@ public abstract class FixBarcodeAbstractArgumentCollection implements Serializab
     }
 
     /** Implementation with barocde qualities */
-    private static final class FixBarcodeWithQualitiesArgumentCollection
+    protected static final class FixBarcodeWithQualitiesArgumentCollection
             extends FixBarcodeAbstractArgumentCollection {
 
         @Argument(fullName = RTStandardArguments.RAW_BARCODE_QUALITIES_TAG_NAME, shortName = RTStandardArguments.RAW_BARCODE_QUALITIES_TAG_NAME, optional = true, common = true,

--- a/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTAbstractOutputBamArgumentCollection.java
+++ b/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTAbstractOutputBamArgumentCollection.java
@@ -62,7 +62,7 @@ abstract class RTAbstractOutputBamArgumentCollection extends RTOutputArgumentCol
     }
 
     /**
-     * Check if {@param outputName} corresponds to a BAM/SAM/CRAM file; if not, throws a
+     * Check if {@code outputName} corresponds to a BAM/SAM/CRAM file; if not, throws a
      */
     protected final void validateUserOutput(final String outputName) {
         if (!ReadToolsIOFormat.isSamBamOrCram(outputName)) {

--- a/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTInputArgumentCollection.java
+++ b/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTInputArgumentCollection.java
@@ -44,7 +44,7 @@ import java.io.Serializable;
  *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class RTInputArgumentCollection implements Serializable {
+public final class RTInputArgumentCollection implements Serializable {
     private static final long serialVersionUID = 1L;
 
     // TODO: change our default validation stringency?

--- a/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputBamArgumentCollection.java
+++ b/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputBamArgumentCollection.java
@@ -40,7 +40,7 @@ import java.nio.file.Path;
  *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-class RTOutputBamArgumentCollection extends RTAbstractOutputBamArgumentCollection {
+public final class RTOutputBamArgumentCollection extends RTAbstractOutputBamArgumentCollection {
     private static final long serialVersionUID = 1L;
 
     @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc = "Output SAM/BAM/CRAM file.", optional = false)

--- a/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputBamSplitArgumentCollection.java
+++ b/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputBamSplitArgumentCollection.java
@@ -49,7 +49,7 @@ import java.util.List;
  *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-class RTOutputBamSplitArgumentCollection extends RTAbstractOutputBamArgumentCollection {
+public final class RTOutputBamSplitArgumentCollection extends RTAbstractOutputBamArgumentCollection {
     private static final long serialVersionUID = 1L;
 
     @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc = "Output SAM/BAM/CRAM file prefix.", optional = false)

--- a/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputFastqArgumentCollection.java
+++ b/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputFastqArgumentCollection.java
@@ -47,7 +47,8 @@ import java.util.function.Supplier;
  *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-final class RTOutputFastqArgumentCollection extends RTOutputArgumentCollection {
+public final class RTOutputFastqArgumentCollection extends RTOutputArgumentCollection {
+    private static final long serialVersionUID = 1L;
 
     // this is the default splitter for pair-end reads.
     private static final List<ReaderSplitter<?>> PAIR_END_SPLITTER =

--- a/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/ReadGroupArgumentCollection.java
+++ b/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/ReadGroupArgumentCollection.java
@@ -39,7 +39,8 @@ import java.io.Serializable;
  *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class ReadGroupArgumentCollection implements Serializable {
+public final class ReadGroupArgumentCollection implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     @Argument(fullName = AddOrReplaceReadGroups.RGLB_LONG_NAME, shortName = AddOrReplaceReadGroups.RGLB_SHORT_NAME, doc = "Read Group Library", optional = true)
     public String readGroupLibrary;

--- a/src/main/java/org/magicdgs/readtools/documentation/RTGSONWorkUnit.java
+++ b/src/main/java/org/magicdgs/readtools/documentation/RTGSONWorkUnit.java
@@ -22,33 +22,17 @@
  * SOFTWARE.
  */
 
-package org.magicdgs.readtools;
+package org.magicdgs.readtools.documentation;
 
-import java.io.File;
+import org.broadinstitute.barclay.help.GSONWorkUnit;
 
 /**
- * Class for utilities for retrieve test resources.
+ * Class representing a GSONWorkUnit for ReadTools work units.
+ *
+ * Does not handle any special tag yet.
  *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public final class TestResourcesUtils {
-
-    // current directory for the tests
-    private static final String CURRENT_DIRECTORY = System.getProperty("user.dir");
-
-    /** The root file directory for main resources files.*/
-    public static final String READTOOLS_MAIN_RESOURCES_DIRECTORY =
-            new File(CURRENT_DIRECTORY, "src/main/resources").getAbsolutePath() + "/";
-
-    /** The root file directory for test resource files. */
-    public static final String READTOOLS_TEST_ROOT_FILE_DIRECTORY =
-            new File(CURRENT_DIRECTORY, "src/test/resources").getAbsolutePath() + "/";
-
-    /**
-     * Gets the test resource as a file in the test source directory.
-     */
-    public static File getReadToolsTestResource(final String fileName) {
-        return new File(READTOOLS_TEST_ROOT_FILE_DIRECTORY, fileName);
-    }
+public class RTGSONWorkUnit extends GSONWorkUnit {
 
 }

--- a/src/main/java/org/magicdgs/readtools/documentation/RTGSONWorkUnit.java
+++ b/src/main/java/org/magicdgs/readtools/documentation/RTGSONWorkUnit.java
@@ -34,5 +34,5 @@ import org.broadinstitute.barclay.help.GSONWorkUnit;
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
 public class RTGSONWorkUnit extends GSONWorkUnit {
-
+    // TODO: see https://github.com/magicDGS/ReadTools/issues/242
 }

--- a/src/main/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandler.java
+++ b/src/main/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandler.java
@@ -38,16 +38,21 @@ import org.broadinstitute.barclay.help.HelpDoclet;
 public class RTHelpDocWorkUnitHandler extends DefaultDocWorkUnitHandler {
 
     /** Default generic template for the documentation work unit. */
-    public static final String DEFAULT_TEMPLATE_NAME = "generic.template.md";
+    public static final String DEFAULT_TEMPLATE_PREFIX = "generic.template.";
 
     public RTHelpDocWorkUnitHandler(HelpDoclet doclet) {
         super(doclet);
     }
 
-    /** Returns {@link #DEFAULT_TEMPLATE_NAME}. */
+    /**
+     * Returns {@link #DEFAULT_TEMPLATE_PREFIX} with the output extension
+     *
+     * <p>Note: does not honor the output file extension option.
+     */
     @Override
     public String getTemplateName(final DocWorkUnit workUnit) {
-        return DEFAULT_TEMPLATE_NAME;
+        // TODO: honor index file extension option (requires https://github.com/broadinstitute/barclay/pull/60 in)
+        return DEFAULT_TEMPLATE_PREFIX + RTHelpDoclet.MARKDOWN_OUTPUT_FILE_EXTENSION;
     }
 
     /** No custom tags are output in ReadToools. */
@@ -100,6 +105,6 @@ public class RTHelpDocWorkUnitHandler extends DefaultDocWorkUnitHandler {
     public String getDestinationFilename(final DocWorkUnit workUnit) {
         // TODO: should use getDoclet().getOutputFileExtension() but requires https://github.com/broadinstitute/barclay/pull/60
         // TODO: see https://github.com/magicDGS/ReadTools/issues/240
-        return workUnit.getName() + ".md";
+        return workUnit.getName() + "." + RTHelpDoclet.MARKDOWN_OUTPUT_FILE_EXTENSION;
     }
 }

--- a/src/main/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandler.java
+++ b/src/main/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandler.java
@@ -27,7 +27,6 @@ package org.magicdgs.readtools.documentation;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DefaultDocWorkUnitHandler;
 import org.broadinstitute.barclay.help.DocWorkUnit;
-import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.barclay.help.HelpDoclet;
 
 /**

--- a/src/main/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandler.java
+++ b/src/main/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandler.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.magicdgs.readtools.documentation;
+
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DefaultDocWorkUnitHandler;
+import org.broadinstitute.barclay.help.DocWorkUnit;
+import org.broadinstitute.barclay.help.HelpDoclet;
+
+/**
+ * The ReadTools Documentation work unit handler class that is the companion to
+ * {@link RTHelpDocWorkUnitHandler}.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class RTHelpDocWorkUnitHandler extends DefaultDocWorkUnitHandler {
+
+    /** Default generic template for the documentation work unit. */
+    public static final String DEFAULT_TEMPLATE_NAME = "generic.template.md";
+
+    public RTHelpDocWorkUnitHandler(HelpDoclet doclet) {
+        super(doclet);
+    }
+
+    /** Returns {@link #DEFAULT_TEMPLATE_NAME}. */
+    @Override
+    public String getTemplateName(final DocWorkUnit workUnit) {
+        return DEFAULT_TEMPLATE_NAME;
+    }
+
+    /** No custom tags are output in ReadToools. */
+    @Override
+    protected String getTagFilterPrefix() {
+        // TODO: add custom tags?
+        return "";
+    }
+
+    /**
+     * Use the {@link CommandLineProgramProperties#summary} instead of the javadoc annotation.
+     * If it is not a command line, it uses the default implementation.
+     */
+    @Override
+    protected String getDescription(final DocWorkUnit currentWorkUnit) {
+        // TODO: uncomment when there is a better description in the javadoc
+        // TODO: in that case, this method will delegate into the current implementation is there is no javadoc
+//        final String description = super.getDescription(currentWorkUnit);
+//        if (!(description == null || description.isEmpty())) {
+//            return description;
+//        }
+        // TODO: remove this if the previous lines are uncommented
+        final CommandLineProgramProperties properties = currentWorkUnit.getCommandLineProperties();
+        if (properties == null) {
+            return super.getDescription(currentWorkUnit);
+        }
+        return properties.summary();
+    }
+
+    @Override
+    public String getDestinationFilename(final DocWorkUnit workUnit) {
+        // TODO: should use getDoclet().getOutputFileExtension() but requires that it is public
+        return workUnit.getName() + ".md";
+    }
+}

--- a/src/main/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandler.java
+++ b/src/main/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandler.java
@@ -53,7 +53,7 @@ public class RTHelpDocWorkUnitHandler extends DefaultDocWorkUnitHandler {
     /** No custom tags are output in ReadToools. */
     @Override
     protected String getTagFilterPrefix() {
-        // TODO: add custom tags?
+        // TODO: add custom tags (https://github.com/magicDGS/ReadTools/issues/242)
         return "";
     }
 
@@ -63,13 +63,9 @@ public class RTHelpDocWorkUnitHandler extends DefaultDocWorkUnitHandler {
      */
     @Override
     protected String getDescription(final DocWorkUnit currentWorkUnit) {
-        // TODO: uncomment when there is a better description in the javadoc
-        // TODO: in that case, this method will delegate into the current implementation is there is no javadoc
-//        final String description = super.getDescription(currentWorkUnit);
-//        if (!(description == null || description.isEmpty())) {
-//            return description;
-//        }
-        // TODO: remove this if the previous lines are uncommented
+        // TODO: we need a different approach for this (see https://github.com/magicDGS/ReadTools/issues/241)
+        // TODO: we should use the default (super method) and if it is nul or empty delegates in
+        // TODO: currentWorkUnit.getCommandLineProperties().summary() - maybe this should be discouraged
         final CommandLineProgramProperties properties = currentWorkUnit.getCommandLineProperties();
         if (properties == null) {
             return super.getDescription(currentWorkUnit);
@@ -77,9 +73,14 @@ public class RTHelpDocWorkUnitHandler extends DefaultDocWorkUnitHandler {
         return properties.summary();
     }
 
+    /**
+     * Destination filename uses
+     * <p>WARNING: does not honor the output extension.
+     */
     @Override
     public String getDestinationFilename(final DocWorkUnit workUnit) {
-        // TODO: should use getDoclet().getOutputFileExtension() but requires that it is public
+        // TODO: should use getDoclet().getOutputFileExtension() but requires https://github.com/broadinstitute/barclay/pull/60
+        // TODO: see https://github.com/magicDGS/ReadTools/issues/240
         return workUnit.getName() + ".md";
     }
 }

--- a/src/main/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandler.java
+++ b/src/main/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandler.java
@@ -27,6 +27,7 @@ package org.magicdgs.readtools.documentation;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DefaultDocWorkUnitHandler;
 import org.broadinstitute.barclay.help.DocWorkUnit;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.barclay.help.HelpDoclet;
 
 /**
@@ -58,24 +59,43 @@ public class RTHelpDocWorkUnitHandler extends DefaultDocWorkUnitHandler {
     }
 
     /**
-     * Use the {@link CommandLineProgramProperties#summary} instead of the javadoc annotation.
-     * If it is not a command line, it uses the default implementation.
+     * Uses different descriptions depending on the work unit content:
+     *
+     * - If the unit is for a command line program, uses {@link CommandLineProgramProperties#summary()}.
+     * - Gets the summary for the documented feature if available.
+     * - Otherwise, use the default method.
      */
+    // TODO: we need a different approach for this (see https://github.com/magicDGS/ReadTools/issues/241)
+    // TODO: we should use the default (super method) and if it is nul or empty delegates in
+    // TODO: currentWorkUnit.getCommandLineProperties().summary() - maybe this should be discouraged
     @Override
     protected String getDescription(final DocWorkUnit currentWorkUnit) {
-        // TODO: we need a different approach for this (see https://github.com/magicDGS/ReadTools/issues/241)
-        // TODO: we should use the default (super method) and if it is nul or empty delegates in
-        // TODO: currentWorkUnit.getCommandLineProperties().summary() - maybe this should be discouraged
+        String description = "";
         final CommandLineProgramProperties properties = currentWorkUnit.getCommandLineProperties();
-        if (properties == null) {
-            return super.getDescription(currentWorkUnit);
+
+        // 1. Command line summary
+        if (properties != null) {
+            description = properties.summary();
         }
-        return properties.summary();
+
+        // 2. Use the documented feature
+        if (description.isEmpty()) {
+            // the documented feature should not be null
+            description = currentWorkUnit.getDocumentedFeature().summary();
+        }
+
+        // 3. Default implementation
+        if (description.isEmpty()) {
+            description = super.getDescription(currentWorkUnit);
+        }
+
+        return description;
     }
 
     /**
-     * Destination filename uses
-     * <p>WARNING: does not honor the output extension.
+     * Uses the name for the unit with the Markdonw suffix (<i>.md</i>).
+     *
+     * <p>WARNING: does not honor the output extension (should be fixed in the future).
      */
     @Override
     public String getDestinationFilename(final DocWorkUnit workUnit) {

--- a/src/main/java/org/magicdgs/readtools/documentation/RTHelpDoclet.java
+++ b/src/main/java/org/magicdgs/readtools/documentation/RTHelpDoclet.java
@@ -1,0 +1,122 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.magicdgs.readtools.documentation;
+
+import org.magicdgs.readtools.RTHelpConstants;
+
+import com.sun.javadoc.ClassDoc;
+import com.sun.javadoc.RootDoc;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocWorkUnit;
+import org.broadinstitute.barclay.help.DocumentedFeature;
+import org.broadinstitute.barclay.help.GSONWorkUnit;
+import org.broadinstitute.barclay.help.HelpDoclet;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Custom Barclay-based Javadoc Doclet used for generating ReadTools help/documentation.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class RTHelpDoclet extends HelpDoclet {
+
+    /** Markdown extension is our default. */
+    public static final String MARKDOWN_OUTPUT_FILE_EXTENSION = ".md";
+
+    /**
+     * Generic index template name for ReadTools documentation.
+     */
+    public static final String INDEX_TEMPLATE_NAME = "generic.index.template.yml";
+
+    /** Constructor with our {@link #MARKDOWN_OUTPUT_FILE_EXTENSION}. */
+    public RTHelpDoclet() {
+        super();
+        // default extension is Markdown
+        outputFileExtension = MARKDOWN_OUTPUT_FILE_EXTENSION;
+    }
+
+    /**
+     * Create a doclet of the appropriate type and generate the FreeMarker templates properties.
+     */
+    public static boolean start(final RootDoc rootDoc) throws IOException {
+        return new org.magicdgs.readtools.documentation.RTHelpDoclet().startProcessDocs(rootDoc);
+    }
+
+    /**
+     * Returns {@link #INDEX_TEMPLATE_NAME}.
+     */
+    @Override
+    protected String getIndexTemplateName() {
+        return INDEX_TEMPLATE_NAME;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Note: uses the {@link RTHelpDocWorkUnitHandler}.
+     */
+    @Override
+    protected DocWorkUnit createWorkUnit(
+            final DocumentedFeature documentedFeature,
+            final CommandLineProgramProperties commmandLineProgramProperties,
+            final ClassDoc classDoc,
+            final Class<?> clazz) {
+        return new DocWorkUnit(
+                new RTHelpDocWorkUnitHandler(this),
+                documentedFeature,
+                commmandLineProgramProperties,
+                classDoc,
+                clazz);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Note: uses the {@link RTGSONWorkUnit}.
+     */
+    @Override
+    protected GSONWorkUnit createGSONWorkUnit(
+            final DocWorkUnit workUnit,
+            final List<Map<String, String>> groupMaps,
+            final List<Map<String, String>> featureMaps) {
+        final RTGSONWorkUnit gsonWorkUnit = new RTGSONWorkUnit();
+        // TODO: add custom values if RTGSONWorkUnit requires it
+        return gsonWorkUnit;
+    }
+
+    /**
+     * Adds a 'supercat' entry to the map using the {@link RTHelpConstants} for the work unit group
+     * name.
+     */
+    @Override
+    protected final Map<String, String> getGroupMap(final DocWorkUnit docWorkUnit) {
+        final Map<String, String> root = super.getGroupMap(docWorkUnit);
+        root.put("supercat", RTHelpConstants.getSuperCategoryProperty(docWorkUnit.getGroupName()));
+        return root;
+    }
+}

--- a/src/main/java/org/magicdgs/readtools/documentation/RTHelpDoclet.java
+++ b/src/main/java/org/magicdgs/readtools/documentation/RTHelpDoclet.java
@@ -105,7 +105,7 @@ public class RTHelpDoclet extends HelpDoclet {
             final List<Map<String, String>> groupMaps,
             final List<Map<String, String>> featureMaps) {
         final RTGSONWorkUnit gsonWorkUnit = new RTGSONWorkUnit();
-        // TODO: add custom values if RTGSONWorkUnit requires it
+        // TODO: update RTGSONWorkUnit (see https://github.com/magicDGS/ReadTools/issues/242)
         return gsonWorkUnit;
     }
 

--- a/src/main/java/org/magicdgs/readtools/documentation/RTHelpDoclet.java
+++ b/src/main/java/org/magicdgs/readtools/documentation/RTHelpDoclet.java
@@ -46,18 +46,21 @@ import java.util.Map;
 public class RTHelpDoclet extends HelpDoclet {
 
     /** Markdown extension is our default. */
-    public static final String MARKDOWN_OUTPUT_FILE_EXTENSION = ".md";
+    public static final String MARKDOWN_OUTPUT_FILE_EXTENSION = "md";
 
-    /**
-     * Generic index template name for ReadTools documentation.
-     */
-    public static final String INDEX_TEMPLATE_NAME = "generic.index.template.yml";
+    /** YML is our default index extension. */
+    public static final String YML_INDEX_FILE_EXTENSION = "yml";
+
+    /** Generic index template name for ReadTools documentation. */
+    public static final String INDEX_TEMPLATE_PREFIX = "generic.index.template.";
 
     /** Constructor with our {@link #MARKDOWN_OUTPUT_FILE_EXTENSION}. */
     public RTHelpDoclet() {
         super();
         // default extension is Markdown
         outputFileExtension = MARKDOWN_OUTPUT_FILE_EXTENSION;
+        // TODO: override indexFileExtension
+        // TODO: requires https://github.com/broadinstitute/barclay/pull/60 and https://github.com/magicDGS/ReadTools/issues/243
     }
 
     /**
@@ -68,11 +71,14 @@ public class RTHelpDoclet extends HelpDoclet {
     }
 
     /**
-     * Returns {@link #INDEX_TEMPLATE_NAME}.
+     * Returns {@link #INDEX_TEMPLATE_PREFIX} with the index file extension.
+     *
+     * <p>Note: it does not honor the index file extension option.
      */
     @Override
     protected String getIndexTemplateName() {
-        return INDEX_TEMPLATE_NAME;
+        // TODO: honor index file extension option (requires https://github.com/broadinstitute/barclay/pull/60 in)
+        return INDEX_TEMPLATE_PREFIX + YML_INDEX_FILE_EXTENSION;
     }
 
     /**

--- a/src/main/java/org/magicdgs/readtools/documentation/package-info.java
+++ b/src/main/java/org/magicdgs/readtools/documentation/package-info.java
@@ -22,33 +22,14 @@
  * SOFTWARE.
  */
 
-package org.magicdgs.readtools;
-
-import java.io.File;
-
 /**
- * Class for utilities for retrieve test resources.
+ * Custom Barclay-based Javadoc classes used for generating ReadTools help/documentation.
+ *
+ * <p>NOTE: Classes and methods in this package are intended to be called by Gradle/Javadoc only,
+ * and should not be called by methods that are used by the runtime. Dependends on com.sun.javadoc
+ * classes, which may not be present since they're not provided as part of the normal runtime
+ * classpath.
  *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public final class TestResourcesUtils {
-
-    // current directory for the tests
-    private static final String CURRENT_DIRECTORY = System.getProperty("user.dir");
-
-    /** The root file directory for main resources files.*/
-    public static final String READTOOLS_MAIN_RESOURCES_DIRECTORY =
-            new File(CURRENT_DIRECTORY, "src/main/resources").getAbsolutePath() + "/";
-
-    /** The root file directory for test resource files. */
-    public static final String READTOOLS_TEST_ROOT_FILE_DIRECTORY =
-            new File(CURRENT_DIRECTORY, "src/test/resources").getAbsolutePath() + "/";
-
-    /**
-     * Gets the test resource as a file in the test source directory.
-     */
-    public static File getReadToolsTestResource(final String fileName) {
-        return new File(READTOOLS_TEST_ROOT_FILE_DIRECTORY, fileName);
-    }
-
-}
+package org.magicdgs.readtools.documentation;

--- a/src/main/java/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode.java
+++ b/src/main/java/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode.java
@@ -43,6 +43,7 @@ import htsjdk.samtools.metrics.MetricsFile;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.GATKReadWriter;
@@ -73,6 +74,7 @@ import java.nio.file.Path;
                 + "barcodes present in the library to the parameter.\n"
                 + "\nFind more information in " + RTHelpConstants.DOCUMENTATION_PAGE,
         programGroup = RTManipulationProgramGroup.class)
+@DocumentedFeature
 public final class AssignReadGroupByBarcode extends ReadToolsWalker {
 
     @ArgumentCollection

--- a/src/main/java/org/magicdgs/readtools/tools/conversion/ReadsToFastq.java
+++ b/src/main/java/org/magicdgs/readtools/tools/conversion/ReadsToFastq.java
@@ -35,6 +35,7 @@ import org.magicdgs.readtools.utils.read.ReadWriterFactory;
 import htsjdk.samtools.SAMFileHeader;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.GATKReadWriter;
 import scala.Tuple2;
@@ -57,6 +58,7 @@ import scala.Tuple2;
                 +" for more information about how standard barcode information is handled in "
                 + "ReadTools and when it is useful.",
         programGroup = RTConversionProgramGroup.class)
+@DocumentedFeature
 public final class ReadsToFastq extends ReadToolsWalker {
 
     @ArgumentCollection

--- a/src/main/java/org/magicdgs/readtools/tools/conversion/StandardizeReads.java
+++ b/src/main/java/org/magicdgs/readtools/tools/conversion/StandardizeReads.java
@@ -34,6 +34,7 @@ import org.magicdgs.readtools.utils.read.ReadWriterFactory;
 import htsjdk.samtools.SAMFileHeader;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.GATKReadWriter;
 import scala.Tuple2;
@@ -61,6 +62,7 @@ import scala.Tuple2;
                 + "(does not require any barcode option).\n"
                 + "\nFind more information in " + RTHelpConstants.DOCUMENTATION_PAGE,
         programGroup = RTConversionProgramGroup.class)
+@DocumentedFeature
 public final class StandardizeReads extends ReadToolsWalker {
 
     @ArgumentCollection

--- a/src/main/java/org/magicdgs/readtools/tools/distmap/DownloadDistmapResult.java
+++ b/src/main/java/org/magicdgs/readtools/tools/distmap/DownloadDistmapResult.java
@@ -31,6 +31,7 @@ import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.argparser.Hidden;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
@@ -60,6 +61,7 @@ import java.util.stream.Collectors;
                 + "Note: The results are expected to be located in the Hadoop FileSystem (HDFS) and the "
                 + "output file in the local computer for following usage, but it is not restricted.",
         programGroup = DistmapProgramGroup.class)
+@DocumentedFeature
 public final class DownloadDistmapResult extends ReadToolsProgram {
 
     @Argument(fullName = StandardArgumentDefinitions.INPUT_LONG_NAME, shortName = StandardArgumentDefinitions.INPUT_SHORT_NAME, doc = "Input folder to look for Distmap multi-part file results. Expected to be in an HDFS file system.", common = true, optional = false)

--- a/src/main/java/org/magicdgs/readtools/tools/distmap/ReadsToDistmap.java
+++ b/src/main/java/org/magicdgs/readtools/tools/distmap/ReadsToDistmap.java
@@ -37,6 +37,7 @@ import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
@@ -62,6 +63,7 @@ import org.broadinstitute.hellbender.utils.read.GATKReadWriter;
                 +" for more information about how standard barcode information is handled in "
                 + "ReadTools and when it is useful.",
         programGroup = DistmapProgramGroup.class)
+@DocumentedFeature
 public final class ReadsToDistmap extends ReadToolsWalker {
 
     @Argument(fullName = RTStandardArguments.FORCE_OVERWRITE_NAME, shortName = RTStandardArguments.FORCE_OVERWRITE_NAME, doc = "Force output overwriting if it exists", common = true, optional = true)

--- a/src/main/java/org/magicdgs/readtools/tools/quality/QualityEncodingDetector.java
+++ b/src/main/java/org/magicdgs/readtools/tools/quality/QualityEncodingDetector.java
@@ -32,6 +32,7 @@ import org.magicdgs.readtools.utils.read.ReadReaderFactory;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.QCProgramGroup;
 
@@ -43,6 +44,7 @@ import java.io.IOException;
 @CommandLineProgramProperties(oneLineSummary = "Detects the quality encoding format for all kind of sources for ReadTools.",
         summary = "Detects the quality encoding for a SAM/BAM/CRAM/FASTQ files, output to the STDOUT the quality encoding.",
         programGroup = QCProgramGroup.class)
+@DocumentedFeature
 public final class QualityEncodingDetector extends ReadToolsProgram {
 
     @Argument(fullName = StandardArgumentDefinitions.INPUT_LONG_NAME, shortName = StandardArgumentDefinitions.INPUT_SHORT_NAME, doc = "Reads input.", optional = false, common = true)

--- a/src/main/java/org/magicdgs/readtools/tools/trimming/TrimReads.java
+++ b/src/main/java/org/magicdgs/readtools/tools/trimming/TrimReads.java
@@ -47,6 +47,7 @@ import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineParser;
 import org.broadinstitute.barclay.argparser.CommandLinePluginDescriptor;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.GATKPlugin.GATKReadFilterPluginDescriptor;
 import org.broadinstitute.hellbender.engine.filters.ReadLengthReadFilter;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -80,9 +81,7 @@ import java.util.List;
                 + " in combination with the new ordering.\n"
                 + "\nFind more information in " + RTHelpConstants.DOCUMENTATION_PAGE,
         programGroup = RTManipulationProgramGroup.class)
-// TODO: this could not be documented yet because the read filter plugin descriptor is broken
-// TODO: see https://github.com/magicDGS/ReadTools/issues/239
-// @DocumentedFeature
+@DocumentedFeature
 public final class TrimReads extends ReadToolsWalker {
 
     @ArgumentCollection

--- a/src/main/java/org/magicdgs/readtools/tools/trimming/TrimReads.java
+++ b/src/main/java/org/magicdgs/readtools/tools/trimming/TrimReads.java
@@ -80,6 +80,9 @@ import java.util.List;
                 + " in combination with the new ordering.\n"
                 + "\nFind more information in " + RTHelpConstants.DOCUMENTATION_PAGE,
         programGroup = RTManipulationProgramGroup.class)
+// TODO: this could not be documented because a known issue with the GATK filer plugin
+// TODO: https://github.com/broadinstitute/gatk-protected/issues/1048
+// @DocumentedFeature
 public final class TrimReads extends ReadToolsWalker {
 
     @ArgumentCollection

--- a/src/main/java/org/magicdgs/readtools/tools/trimming/TrimReads.java
+++ b/src/main/java/org/magicdgs/readtools/tools/trimming/TrimReads.java
@@ -80,8 +80,8 @@ import java.util.List;
                 + " in combination with the new ordering.\n"
                 + "\nFind more information in " + RTHelpConstants.DOCUMENTATION_PAGE,
         programGroup = RTManipulationProgramGroup.class)
-// TODO: this could not be documented because a known issue with the GATK filer plugin
-// TODO: https://github.com/broadinstitute/gatk-protected/issues/1048
+// TODO: this could not be documented yet because the read filter plugin descriptor is broken
+// TODO: see https://github.com/magicDGS/ReadTools/issues/239
 // @DocumentedFeature
 public final class TrimReads extends ReadToolsWalker {
 

--- a/src/main/java/org/magicdgs/readtools/utils/read/transformer/trimming/CutReadTrimmer.java
+++ b/src/main/java/org/magicdgs/readtools/utils/read/transformer/trimming/CutReadTrimmer.java
@@ -36,7 +36,7 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
  *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-@DocumentedFeature(groupName = RTHelpConstants.DOC_CAT_TRIMMERS, groupSummary = RTHelpConstants.DOC_CAT_TRIMMERS_SUMMARY, summary = "Trims the read certain number of bases at the end of the read.")
+@DocumentedFeature(groupName = RTHelpConstants.DOC_CAT_TRIMMERS, groupSummary = RTHelpConstants.DOC_CAT_TRIMMERS_SUMMARY, summary = "Trims a concrete number of bases at the end of the read.")
 public class CutReadTrimmer extends TrimmingFunction {
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/org/magicdgs/readtools/utils/read/transformer/trimming/CutReadTrimmer.java
+++ b/src/main/java/org/magicdgs/readtools/utils/read/transformer/trimming/CutReadTrimmer.java
@@ -24,8 +24,11 @@
 
 package org.magicdgs.readtools.utils.read.transformer.trimming;
 
+import org.magicdgs.readtools.RTHelpConstants;
+
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineException;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 /**
@@ -33,6 +36,7 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
  *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
+@DocumentedFeature(groupName = RTHelpConstants.DOC_CAT_TRIMMERS, groupSummary = RTHelpConstants.DOC_CAT_TRIMMERS_SUMMARY, summary = "Trims the read certain number of bases at the end of the read.")
 public class CutReadTrimmer extends TrimmingFunction {
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/org/magicdgs/readtools/utils/read/transformer/trimming/MottQualityTrimmer.java
+++ b/src/main/java/org/magicdgs/readtools/utils/read/transformer/trimming/MottQualityTrimmer.java
@@ -24,10 +24,12 @@
 
 package org.magicdgs.readtools.utils.read.transformer.trimming;
 
+import org.magicdgs.readtools.RTHelpConstants;
 import org.magicdgs.readtools.utils.trimming.TrimmingUtil;
 
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineException;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
@@ -37,6 +39,7 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
  *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
+@DocumentedFeature(groupName = RTHelpConstants.DOC_CAT_TRIMMERS, groupSummary = RTHelpConstants.DOC_CAT_TRIMMERS_SUMMARY, summary = "Trims low quality ends using the  Mott's algorithm.")
 public final class MottQualityTrimmer extends TrimmingFunction {
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/org/magicdgs/readtools/utils/read/transformer/trimming/TrailingNtrimmer.java
+++ b/src/main/java/org/magicdgs/readtools/utils/read/transformer/trimming/TrailingNtrimmer.java
@@ -24,8 +24,10 @@
 
 package org.magicdgs.readtools.utils.read.transformer.trimming;
 
+import org.magicdgs.readtools.RTHelpConstants;
 import org.magicdgs.readtools.utils.trimming.TrimmingUtil;
 
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 /**
@@ -34,6 +36,7 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
  *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
+@DocumentedFeature(groupName = RTHelpConstants.DOC_CAT_TRIMMERS, groupSummary = RTHelpConstants.DOC_CAT_TRIMMERS_SUMMARY, summary = "Trims the end of the read containing unknown bases.")
 public final class TrailingNtrimmer extends TrimmingFunction {
     private static final long serialVersionUID = 1L;
 

--- a/src/main/resources/org/magicdgs/readtools/documentation/generic.index.template.yml
+++ b/src/main/resources/org/magicdgs/readtools/documentation/generic.index.template.yml
@@ -1,0 +1,28 @@
+<#-- TODO: add "other" -->
+<#assign seq = ["tools", "utilities"]>
+<#macro emitGroup group>
+  - ${group.name}:
+    - name: ${group.name}
+    - summary: ${group.summary}
+    - components:
+    <#list data as datum>
+      <#if datum.group == group.name>
+      - ${datum.name}:
+        - name: ${datum.name}
+        - summary: ${datum.summary}
+      </#if>
+    </#list>
+</#macro>
+- ReadTools:
+  - version: ${version}
+  - timestamp: ${timestamp}
+
+<#list seq as supercat>
+- ${supercat}:
+  <#list groups?sort_by("name") as group>
+    <#if group.supercat == supercat>
+      <@emitGroup group=group/>
+	</#if>
+  </#list>
+  
+</#list>

--- a/src/main/resources/org/magicdgs/readtools/documentation/generic.index.template.yml
+++ b/src/main/resources/org/magicdgs/readtools/documentation/generic.index.template.yml
@@ -1,15 +1,19 @@
 <#-- TODO: add "other" -->
 <#assign seq = ["tools", "utilities"]>
 <#macro emitGroup group>
+  <#-- Do not allow new lines in the summaries -->
+  <#assign group_summary = group.summary?replace("\n", " ", 'r')>
   - ${group.name}:
     - name: ${group.name}
-    - summary: ${group.summary}
+    - summary: ${group_summary}
     - components:
     <#list data as datum>
       <#if datum.group == group.name>
+      <#-- Do not allow new lines in the summaries -->
+      <#assign datum_summary = datum.summary?replace("\n", " ", 'r')>
       - ${datum.name}:
         - name: ${datum.name}
-        - summary: ${datum.summary}
+        - summary: ${datum_summary}
       </#if>
     </#list>
 </#macro>

--- a/src/main/resources/org/magicdgs/readtools/documentation/generic.template.md
+++ b/src/main/resources/org/magicdgs/readtools/documentation/generic.template.md
@@ -1,0 +1,34 @@
+<#macro argumentlist name myargs>
+    <#if myargs?size != 0>
+### ${name}
+
+| Argument name(s) | Type | Default value(s) | Summary |
+| :--------------- | :--: | :--------------: | :------ |
+        <#list myargs as arg>
+| `${arg.name}`<#if arg.synonyms != "NA">,`${arg.synonyms}`</#if> | ${arg.type} | ${arg.defaultValue} | ${arg.summary} |
+        </#list>
+
+	</#if>
+</#macro>
+---
+title: ${name}
+summary: ${summary}
+permalink: ${name}.html
+last_updated: ${timestamp}
+---
+
+## Description
+
+${description}
+
+<#if arguments.all?size != 0>
+## Arguments
+
+<@argumentlist name="Positional Arguments" myargs=arguments.positional/>
+<@argumentlist name="Required Arguments" myargs=arguments.required/>
+<@argumentlist name="Optional Arguments" myargs=arguments.optional/>
+<@argumentlist name="Optional Common Arguments" myargs=arguments.common/>
+<@argumentlist name="Advanced Arguments" myargs=arguments.advanced/>
+<@argumentlist name="Deprecated Arguments" myargs=arguments.deprecated/>
+
+</#if>

--- a/src/test/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandlerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandlerUnitTest.java
@@ -22,33 +22,44 @@
  * SOFTWARE.
  */
 
-package org.magicdgs.readtools;
+package org.magicdgs.readtools.documentation;
+
+import org.magicdgs.readtools.RTBaseTest;
+
+import org.broadinstitute.barclay.help.DocWorkUnit;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 import java.io.File;
 
 /**
- * Class for utilities for retrieve test resources.
- *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public final class TestResourcesUtils {
+public class RTHelpDocWorkUnitHandlerUnitTest extends RTBaseTest{
 
-    // current directory for the tests
-    private static final String CURRENT_DIRECTORY = System.getProperty("user.dir");
+    private static final RTHelpDocWorkUnitHandler HANDLER =
+            new RTHelpDocWorkUnitHandler(RTHelpDocletUnitTest.DOCLET);
 
-    /** The root file directory for main resources files.*/
-    public static final String READTOOLS_MAIN_RESOURCES_DIRECTORY =
-            new File(CURRENT_DIRECTORY, "src/main/resources").getAbsolutePath() + "/";
+    @Test
+    public void testTemplateName() {
+        final File template = new File(RTHelpDocletUnitTest.DOCUMENTATION_TEMPLATES_FOLDER,
+                HANDLER.getTemplateName(null));
+        // check that our index template exists in the resources folder
+        Assert.assertTrue(template.exists(),
+                "index template does not exists: " + template);
+    }
 
-    /** The root file directory for test resource files. */
-    public static final String READTOOLS_TEST_ROOT_FILE_DIRECTORY =
-            new File(CURRENT_DIRECTORY, "src/test/resources").getAbsolutePath() + "/";
+    @Test
+    public void testGetTagFilterPrefix() {
+        Assert.assertEquals(HANDLER.getTagFilterPrefix(), "");
+    }
 
-    /**
-     * Gets the test resource as a file in the test source directory.
-     */
-    public static File getReadToolsTestResource(final String fileName) {
-        return new File(READTOOLS_TEST_ROOT_FILE_DIRECTORY, fileName);
+    @Test
+    public void testGetDestinationFilename() {
+        final DocWorkUnit mockedWorkUnit = Mockito.mock(DocWorkUnit.class);
+        Mockito.when(mockedWorkUnit.getName()).thenReturn("MyToolName");
+        Assert.assertEquals(HANDLER.getDestinationFilename(mockedWorkUnit), "MyToolName.md");
     }
 
 }

--- a/src/test/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandlerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandlerUnitTest.java
@@ -75,6 +75,7 @@ public class RTHelpDocWorkUnitHandlerUnitTest extends RTBaseTest {
         Assert.assertEquals(HANDLER.getDescription(mockedWorkUnit), "Summary for CLP");
     }
 
+    @Test
     public void testGetDescriptionFromDocumentedFeature() {
         @DocumentedFeature(summary = "Summary for DocumentedFeature")
         final class DocumentedClass {}

--- a/src/test/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandlerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandlerUnitTest.java
@@ -30,7 +30,6 @@ import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocWorkUnit;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.TestProgramGroup;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -91,5 +90,4 @@ public class RTHelpDocWorkUnitHandlerUnitTest extends RTBaseTest {
                 .thenReturn(clazz.getAnnotation(DocumentedFeature.class));
         return mockedWorkUnit;
     }
-
 }

--- a/src/test/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandlerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandlerUnitTest.java
@@ -26,7 +26,11 @@ package org.magicdgs.readtools.documentation;
 
 import org.magicdgs.readtools.RTBaseTest;
 
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocWorkUnit;
+import org.broadinstitute.barclay.help.DocumentedFeature;
+import org.broadinstitute.hellbender.cmdline.TestProgramGroup;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -36,7 +40,7 @@ import java.io.File;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class RTHelpDocWorkUnitHandlerUnitTest extends RTBaseTest{
+public class RTHelpDocWorkUnitHandlerUnitTest extends RTBaseTest {
 
     private static final RTHelpDocWorkUnitHandler HANDLER =
             new RTHelpDocWorkUnitHandler(RTHelpDocletUnitTest.DOCLET);
@@ -60,6 +64,31 @@ public class RTHelpDocWorkUnitHandlerUnitTest extends RTBaseTest{
         final DocWorkUnit mockedWorkUnit = Mockito.mock(DocWorkUnit.class);
         Mockito.when(mockedWorkUnit.getName()).thenReturn("MyToolName");
         Assert.assertEquals(HANDLER.getDestinationFilename(mockedWorkUnit), "MyToolName.md");
+    }
+
+    @Test
+    public void testGetDescriptionFromCommandLine() {
+        @CommandLineProgramProperties(summary = "Summary for CLP", oneLineSummary = "One line summary for CLP", programGroup = TestProgramGroup.class)
+        @DocumentedFeature(summary = "Summary for DocumentedFeature")
+        final class CLPClass {}
+        final DocWorkUnit mockedWorkUnit = mockedWorkUnit(CLPClass.class);
+        Assert.assertEquals(HANDLER.getDescription(mockedWorkUnit), "Summary for CLP");
+    }
+
+    public void testGetDescriptionFromDocumentedFeature() {
+        @DocumentedFeature(summary = "Summary for DocumentedFeature")
+        final class DocumentedClass {}
+        final DocWorkUnit mockedWorkUnit = mockedWorkUnit(DocumentedClass.class);
+        Assert.assertEquals(HANDLER.getDescription(mockedWorkUnit), "Summary for DocumentedFeature");
+    }
+
+    private static final DocWorkUnit mockedWorkUnit(final Class<?> clazz) {
+        final DocWorkUnit mockedWorkUnit = Mockito.mock(DocWorkUnit.class);
+        Mockito.when(mockedWorkUnit.getCommandLineProperties())
+                .thenReturn(clazz.getAnnotation(CommandLineProgramProperties.class));
+        Mockito.when(mockedWorkUnit.getDocumentedFeature())
+                .thenReturn(clazz.getAnnotation(DocumentedFeature.class));
+        return mockedWorkUnit;
     }
 
 }

--- a/src/test/java/org/magicdgs/readtools/documentation/RTHelpDocletUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/documentation/RTHelpDocletUnitTest.java
@@ -103,6 +103,5 @@ public class RTHelpDocletUnitTest extends RTBaseTest {
         final List<String> generatedFiles = Arrays.asList(outputDir.list());
         // there are at least 1 trimmers is implemented (md + json)
         Assert.assertTrue(generatedFiles.size() > 2, "Trimmers and index should be present: " + generatedFiles);
-
     }
 }

--- a/src/test/java/org/magicdgs/readtools/documentation/RTHelpDocletUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/documentation/RTHelpDocletUnitTest.java
@@ -87,7 +87,7 @@ public class RTHelpDocletUnitTest extends RTBaseTest {
                 "-build-timestamp", "2016/01/01 01:01:01",      // dummy, constant timestamp
                 "-absolute-version", "11.1",                    // dummy version
                 "-output-file-extension", "md",                 // testing markdown output
-                // TODO: this should be uncommented at some point
+                // TODO: undocument after https://github.com/magicDGS/ReadTools/issues/243
                 // "-index-file-extension", "yml",
                 "-docletpath", "build/libs",
                 "-settings-dir", DOCUMENTATION_TEMPLATES_FOLDER,

--- a/src/test/java/org/magicdgs/readtools/documentation/RTHelpDocletUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/documentation/RTHelpDocletUnitTest.java
@@ -75,5 +75,4 @@ public class RTHelpDocletUnitTest extends RTBaseTest {
         Assert.assertEquals(groupMap.get("summary"), "group_summary");
         Assert.assertEquals(groupMap.get("supercat"), "other");
     }
-
 }

--- a/src/test/java/org/magicdgs/readtools/documentation/RTHelpDocletUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/documentation/RTHelpDocletUnitTest.java
@@ -1,0 +1,79 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.magicdgs.readtools.documentation;
+
+import org.magicdgs.readtools.RTBaseTest;
+import org.magicdgs.readtools.TestResourcesUtils;
+
+import org.broadinstitute.barclay.help.DocWorkUnit;
+import org.broadinstitute.barclay.help.GSONWorkUnit;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Map;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class RTHelpDocletUnitTest extends RTBaseTest {
+
+    /** Folder where templates live. */
+    static final String DOCUMENTATION_TEMPLATES_FOLDER =
+            TestResourcesUtils.READTOOLS_MAIN_RESOURCES_DIRECTORY
+                    + "org/magicdgs/readtools/documentation";
+
+    static final RTHelpDoclet DOCLET = new RTHelpDoclet();
+
+    @Test
+    public void testGetIndexTemplateName() {
+        final File indexTemplate = new File(DOCUMENTATION_TEMPLATES_FOLDER,
+                DOCLET.getIndexTemplateName());
+        // check that our index template exists in the resources folder
+        Assert.assertTrue(indexTemplate.exists(),
+                "index template does not exists: " + indexTemplate);
+    }
+
+    @Test
+    public void testcreateGSONWorkUnit() {
+        // should not fail by using all null, because we have no extra information yet
+        final GSONWorkUnit gsonWorkUnit = DOCLET.createGSONWorkUnit(null, null, null);
+        Assert.assertEquals(gsonWorkUnit.getClass(), RTGSONWorkUnit.class);
+    }
+
+    @Test
+    public void testGetGroupMap() {
+        final DocWorkUnit mockedUnit = Mockito.mock(DocWorkUnit.class);
+        Mockito.when(mockedUnit.getGroupName()).thenReturn("group_name");
+        Mockito.when(mockedUnit.getGroupSummary()).thenReturn("group_summary");
+        final Map<String, String> groupMap = DOCLET.getGroupMap(mockedUnit);
+        Assert.assertEquals(groupMap.get("id"), "group_name");
+        Assert.assertEquals(groupMap.get("name"), "group_name");
+        Assert.assertEquals(groupMap.get("summary"), "group_summary");
+        Assert.assertEquals(groupMap.get("supercat"), "other");
+    }
+
+}

--- a/src/test/java/org/magicdgs/readtools/documentation/RTHelpDocletUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/documentation/RTHelpDocletUnitTest.java
@@ -42,11 +42,11 @@ import java.util.Map;
 public class RTHelpDocletUnitTest extends RTBaseTest {
 
     /** Folder where templates live. */
-    static final String DOCUMENTATION_TEMPLATES_FOLDER =
+    protected static final String DOCUMENTATION_TEMPLATES_FOLDER =
             TestResourcesUtils.READTOOLS_MAIN_RESOURCES_DIRECTORY
                     + "org/magicdgs/readtools/documentation";
 
-    static final RTHelpDoclet DOCLET = new RTHelpDoclet();
+    protected static final RTHelpDoclet DOCLET = new RTHelpDoclet();
 
     @Test
     public void testGetIndexTemplateName() {


### PR DESCRIPTION
Close #182

* Add basic Barclay documentation framework
* Jekyll templates
* Annotate documented features
* Make public argument collection to allow their use in the doc generation