### PR TITLE
Prefer javadoc documentation for description

### DIFF
--- a/src/main/java/org/magicdgs/readtools/documentation/RTGSONWorkUnit.java
+++ b/src/main/java/org/magicdgs/readtools/documentation/RTGSONWorkUnit.java
@@ -27,12 +27,26 @@ package org.magicdgs.readtools.documentation;
 import org.broadinstitute.barclay.help.GSONWorkUnit;
 
 /**
- * Class representing a GSONWorkUnit for ReadTools work units.
- *
- * Does not handle any special tag yet.
+ * Class representing a GSONWorkUnit for ReadTools work units. It handles special tags, as defined
+ * in the setters.
  *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
 public class RTGSONWorkUnit extends GSONWorkUnit {
-    // TODO: see https://github.com/magicDGS/ReadTools/issues/242
+
+    private String note;
+
+    private String warning;
+
+    /** Sets a ReadTools note about the documented feature. */
+    public void setNote(final String note) {
+        this.note = note;
+    }
+
+    /** Sets a ReadTools warning about the documented feature. */
+    public void setWarning(final String warning) {
+        this.warning = warning;
+    }
+
+
 }

--- a/src/main/java/org/magicdgs/readtools/documentation/RTHelpDoclet.java
+++ b/src/main/java/org/magicdgs/readtools/documentation/RTHelpDoclet.java
@@ -35,6 +35,7 @@ import org.broadinstitute.barclay.help.GSONWorkUnit;
 import org.broadinstitute.barclay.help.HelpDoclet;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -70,6 +71,12 @@ public class RTHelpDoclet extends HelpDoclet {
         return new org.magicdgs.readtools.documentation.RTHelpDoclet().startProcessDocs(rootDoc);
     }
 
+    ///////////////////////////////////////////////
+    // Tag names
+    private static final String NOTE_MAP_ENTRY = "note";
+    private static final String WARNING_MAP_ENTRY = "warning";
+
+
     /**
      * Returns {@link #INDEX_TEMPLATE_PREFIX} with the index file extension.
      *
@@ -103,7 +110,7 @@ public class RTHelpDoclet extends HelpDoclet {
     /**
      * {@inheritDoc}
      *
-     * <p>Note: uses the {@link RTGSONWorkUnit}.
+     * <p>Note: uses the {@link RTGSONWorkUnit}, adding custom tags.
      */
     @Override
     protected GSONWorkUnit createGSONWorkUnit(
@@ -111,7 +118,9 @@ public class RTHelpDoclet extends HelpDoclet {
             final List<Map<String, String>> groupMaps,
             final List<Map<String, String>> featureMaps) {
         final RTGSONWorkUnit gsonWorkUnit = new RTGSONWorkUnit();
-        // TODO: update RTGSONWorkUnit (see https://github.com/magicDGS/ReadTools/issues/242)
+        // set the note and the warning from javadocs
+        gsonWorkUnit.setNote((String)workUnit.getProperty(NOTE_MAP_ENTRY));
+        gsonWorkUnit.setWarning((String)workUnit.getProperty(WARNING_MAP_ENTRY));
         return gsonWorkUnit;
     }
 

--- a/src/main/java/org/magicdgs/readtools/documentation/RTHelpDoclet.java
+++ b/src/main/java/org/magicdgs/readtools/documentation/RTHelpDoclet.java
@@ -35,7 +35,6 @@ import org.broadinstitute.barclay.help.GSONWorkUnit;
 import org.broadinstitute.barclay.help.HelpDoclet;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/resources/org/magicdgs/readtools/documentation/generic.template.md
+++ b/src/main/resources/org/magicdgs/readtools/documentation/generic.template.md
@@ -20,6 +20,14 @@ last_updated: ${timestamp}
 ## Description
 
 ${description}
+<#if warning?has_content>
+
+{% include warning.html content='${warning}' %}
+</#if>
+<#if note?has_content>
+
+{% include note.html content='${note}' %}
+</#if>
 
 <#if arguments.all?size != 0>
 ## Arguments

--- a/src/test/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandlerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandlerUnitTest.java
@@ -26,10 +26,7 @@ package org.magicdgs.readtools.documentation;
 
 import org.magicdgs.readtools.RTBaseTest;
 
-import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocWorkUnit;
-import org.broadinstitute.barclay.help.DocumentedFeature;
-import org.broadinstitute.hellbender.cmdline.TestProgramGroup;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -55,7 +52,7 @@ public class RTHelpDocWorkUnitHandlerUnitTest extends RTBaseTest {
 
     @Test
     public void testGetTagFilterPrefix() {
-        Assert.assertEquals(HANDLER.getTagFilterPrefix(), "");
+        Assert.assertEquals(HANDLER.getTagFilterPrefix(), "ReadTools");
     }
 
     @Test
@@ -63,31 +60,5 @@ public class RTHelpDocWorkUnitHandlerUnitTest extends RTBaseTest {
         final DocWorkUnit mockedWorkUnit = Mockito.mock(DocWorkUnit.class);
         Mockito.when(mockedWorkUnit.getName()).thenReturn("MyToolName");
         Assert.assertEquals(HANDLER.getDestinationFilename(mockedWorkUnit), "MyToolName.md");
-    }
-
-    @Test
-    public void testGetDescriptionFromCommandLine() {
-        @CommandLineProgramProperties(summary = "Summary for CLP", oneLineSummary = "One line summary for CLP", programGroup = TestProgramGroup.class)
-        @DocumentedFeature(summary = "Summary for DocumentedFeature")
-        final class CLPClass {}
-        final DocWorkUnit mockedWorkUnit = mockedWorkUnit(CLPClass.class);
-        Assert.assertEquals(HANDLER.getDescription(mockedWorkUnit), "Summary for CLP");
-    }
-
-    @Test
-    public void testGetDescriptionFromDocumentedFeature() {
-        @DocumentedFeature(summary = "Summary for DocumentedFeature")
-        final class DocumentedClass {}
-        final DocWorkUnit mockedWorkUnit = mockedWorkUnit(DocumentedClass.class);
-        Assert.assertEquals(HANDLER.getDescription(mockedWorkUnit), "Summary for DocumentedFeature");
-    }
-
-    private static final DocWorkUnit mockedWorkUnit(final Class<?> clazz) {
-        final DocWorkUnit mockedWorkUnit = Mockito.mock(DocWorkUnit.class);
-        Mockito.when(mockedWorkUnit.getCommandLineProperties())
-                .thenReturn(clazz.getAnnotation(CommandLineProgramProperties.class));
-        Mockito.when(mockedWorkUnit.getDocumentedFeature())
-                .thenReturn(clazz.getAnnotation(DocumentedFeature.class));
-        return mockedWorkUnit;
     }
 }

--- a/src/test/java/org/magicdgs/readtools/documentation/classes/DocumentedClpWithoutJavadoc.java
+++ b/src/test/java/org/magicdgs/readtools/documentation/classes/DocumentedClpWithoutJavadoc.java
@@ -31,8 +31,10 @@ import org.broadinstitute.hellbender.cmdline.TestProgramGroup;
 
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
+ * @ReadTools.note Note in javadoc tag.
+ * @ReadTools.warning Warning in javadoc tag.
  */
-@CommandLineProgramProperties(summary = "Inline summary", oneLineSummary = "Inline oneLineSummary",  programGroup = TestProgramGroup.class)
+@CommandLineProgramProperties(summary = "Inline summary", oneLineSummary = "Inline oneLineSummary", programGroup = TestProgramGroup.class)
 @DocumentedFeature
 public class DocumentedClpWithoutJavadoc {
 

--- a/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/DocumentedClpWithJavadoc.md
+++ b/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/DocumentedClpWithJavadoc.md
@@ -7,7 +7,7 @@ last_updated: 2016/01/01 01:01:01
 
 ## Description
 
-Inline summary
+Description in javadoc.
 
 ## Arguments
 

--- a/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/DocumentedClpWithJavadoc.md.json
+++ b/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/DocumentedClpWithJavadoc.md.json
@@ -17,7 +17,7 @@
       "options": []
     }
   ],
-  "description": "Inline summary",
+  "description": "Description in javadoc.",
   "name": "DocumentedClpWithJavadoc",
   "group": "Test Tools"
 }

--- a/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/DocumentedClpWithoutJavadoc.md
+++ b/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/DocumentedClpWithoutJavadoc.md
@@ -9,6 +9,10 @@ last_updated: 2016/01/01 01:01:01
 
 Inline summary
 
+{% include warning.html content='Warning in javadoc tag.' %}
+
+{% include note.html content='Note in javadoc tag.' %}
+
 ## Arguments
 
 ### Optional Arguments

--- a/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/DocumentedClpWithoutJavadoc.md.json
+++ b/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/DocumentedClpWithoutJavadoc.md.json
@@ -1,4 +1,6 @@
 {
+  "note": "Note in javadoc tag.",
+  "warning": "Warning in javadoc tag.",
   "summary": "Inline oneLineSummary",
   "arguments": [
     {

--- a/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/DocumentedFeatureWithJavadoc.md
+++ b/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/DocumentedFeatureWithJavadoc.md
@@ -7,5 +7,5 @@ last_updated: 2016/01/01 01:01:01
 
 ## Description
 
-Inline summary
+Description in javadoc
 

--- a/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/DocumentedFeatureWithJavadoc.md.json
+++ b/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/DocumentedFeatureWithJavadoc.md.json
@@ -1,7 +1,7 @@
 {
   "summary": "Inline summary",
   "arguments": [],
-  "description": "Inline summary",
+  "description": "Description in javadoc",
   "name": "DocumentedFeatureWithJavadoc",
   "group": "Inline groupName"
 }


### PR DESCRIPTION
- Use the javadoc documentation if possible (closes #241). Otherwise,
  delegates in inline annotation docs
- Handle custom ReadTools tags for notes and warnings (related to #242)
- Update templates to use tags with jekyll includes