### PR TITLE
Update online help templates

### DIFF
--- a/src/main/resources/org/magicdgs/readtools/documentation/generic.template.md
+++ b/src/main/resources/org/magicdgs/readtools/documentation/generic.template.md
@@ -1,11 +1,21 @@
-<#macro argumentlist name myargs>
+<#macro argname arg>`${arg.name}`<#if arg.synonyms != "NA" && arg.synonyms != "-"><br/>`${arg.synonyms}`</#if></#macro>
+<#-- TODO: use something like the following line for include range in argtype
+TODO: it requires a new version of FreeMarker for accessing some mehtods
+<#if arg.minValue?is_number || arg.maxValue?is_number><#if arg.minValue != "-INF" && arg.maxValue != "INF"><br/>[${arg.minValue}, ${arg.maxValue}]</#if></#if>
+-->
+<#macro argtype arg>${arg.type}</#macro>
+<#macro argdesc arg><#if arg.fulltext != "">${arg.fulltext}<#else>${arg.summary}</#if><#if arg.options?size != 0><br/><br/><@argoptions arg=arg/></#if></#macro>
+<#macro argoptions arg><b>Possible values:</b> <#list arg.options as opt><i>${opt.name}</i><#if opt.summary != ""> (${opt.summary})</#if><#if opt_has_next>, </#if></#list></#macro>
+<#macro argumentlist name myargs show_default=true>
     <#if myargs?size != 0>
-### ${name}
+### ${name} Arguments
 
-| Argument name(s) | Type | Default value(s) | Summary |
-| :--------------- | :--: | :--------------: | :------ |
+<#if name == "Deprecated" >{% include warning.html content="Do not use this arguments unless strictly necessary" %}
+</#if>
+| Argument name(s) | Type | <#if show_default>Default value(s) | </#if>Description |
+| :--------------- | :--: | <#if show_default>:--------------: | </#if>:------ |
         <#list myargs as arg>
-| `${arg.name}`<#if arg.synonyms != "NA">,`${arg.synonyms}`</#if> | ${arg.type} | ${arg.defaultValue} | ${arg.summary} |
+| <@argname arg=arg/> | <@argtype arg=arg/> | <#if show_default>${arg.defaultValue} | </#if><@argdesc arg=arg/> |
         </#list>
 
 	</#if>
@@ -28,15 +38,23 @@ ${description}
 
 {% include note.html content='${note}' %}
 </#if>
+<#if extradocs?size != 0>
+
+<i>See additional information in the following pages:</i>
+
+<#list extradocs as extradoc>
+- [${extradoc.name}](${extradoc.name}.html)
+</#list>
+</#if>
 
 <#if arguments.all?size != 0>
 ## Arguments
 
-<@argumentlist name="Positional Arguments" myargs=arguments.positional/>
-<@argumentlist name="Required Arguments" myargs=arguments.required/>
-<@argumentlist name="Optional Arguments" myargs=arguments.optional/>
-<@argumentlist name="Optional Common Arguments" myargs=arguments.common/>
-<@argumentlist name="Advanced Arguments" myargs=arguments.advanced/>
-<@argumentlist name="Deprecated Arguments" myargs=arguments.deprecated/>
+<@argumentlist name="Positional" myargs=arguments.positional show_default=false/>
+<@argumentlist name="Required" myargs=arguments.required show_default=false/>
+<@argumentlist name="Optional" myargs=arguments.optional/>
+<@argumentlist name="Optional Common" myargs=arguments.common/>
+<@argumentlist name="Advanced" myargs=arguments.advanced/>
+<@argumentlist name="Deprecated" myargs=arguments.deprecated show_default=false/>
 
 </#if>

--- a/src/test/java/org/magicdgs/readtools/documentation/classes/DocumentedClpWithJavadoc.java
+++ b/src/test/java/org/magicdgs/readtools/documentation/classes/DocumentedClpWithJavadoc.java
@@ -35,7 +35,7 @@ import org.broadinstitute.hellbender.cmdline.TestProgramGroup;
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
 @CommandLineProgramProperties(summary = "Inline summary", oneLineSummary = "Inline oneLineSummary",  programGroup = TestProgramGroup.class)
-@DocumentedFeature
+@DocumentedFeature(extraDocs = DocumentedClpWithoutJavadoc.class)
 public class DocumentedClpWithJavadoc {
 
     /** Argument in javadoc. */

--- a/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/DocumentedClpWithJavadoc.md
+++ b/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/DocumentedClpWithJavadoc.md
@@ -9,12 +9,16 @@ last_updated: 2016/01/01 01:01:01
 
 Description in javadoc.
 
+<i>See additional information in the following pages:</i>
+
+- [DocumentedClpWithoutJavadoc](DocumentedClpWithoutJavadoc.html)
+
 ## Arguments
 
 ### Optional Arguments
 
-| Argument name(s) | Type | Default value(s) | Summary |
+| Argument name(s) | Type | Default value(s) | Description |
 | :--------------- | :--: | :--------------: | :------ |
-| `--string-argument`,`-s-arg` | String | "" | Inline argument doc |
+| `--string-argument`<br/>`-s-arg` | String | "" | Argument in javadoc. |
 
 

--- a/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/DocumentedClpWithoutJavadoc.md
+++ b/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/DocumentedClpWithoutJavadoc.md
@@ -17,8 +17,8 @@ Inline summary
 
 ### Optional Arguments
 
-| Argument name(s) | Type | Default value(s) | Summary |
+| Argument name(s) | Type | Default value(s) | Description |
 | :--------------- | :--: | :--------------: | :------ |
-| `--string-argument`,`-s-arg` | String | "" | Inline argument doc |
+| `--string-argument`<br/>`-s-arg` | String | "" | Inline argument doc |
 
 


### PR DESCRIPTION
- Do not show defaults for required arguments
- Do not show defaults for deprecated arguments
- Deprecated arguments show a warning
- Macro for argument name: display the synonym in the next line
- Macro for argument type: simple implementation, it may include
  more information in the future (e.g., range)
- Macro for argument description: use javadoc if available, print
  options for enums/plugins (with description)
- Integrate extraDocs after tool/feature description as a list