### PR TITLE
Test distmap-related tools in HDFS cluster

### DIFF
--- a/src/test/java/org/magicdgs/readtools/tools/distmap/DownloadDistmapResultIntegrationTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/distmap/DownloadDistmapResultIntegrationTest.java
@@ -55,12 +55,12 @@ public class DownloadDistmapResultIntegrationTest extends RTCommandLineProgramTe
 
     // init the cluster and copy the files there
     @BeforeClass(alwaysRun = true)
-    private void setupMiniCluster() throws Exception {
+    public void setupMiniCluster() throws Exception {
         // gets the cluster and create the directory
         cluster = MiniClusterUtils.getMiniCluster();
         final Path distmapClusterFolder = IOUtils.getPath(
                 cluster.getFileSystem().getUri().toString()
-                + "/distmap_input/fastq_paired_end_mapping_bwa/");
+                + "/distmap_output/fastq_paired_end_mapping_bwa/");
         Files.createDirectory(distmapClusterFolder);
         clusterInputFolder = distmapClusterFolder.toUri().toString();
 
@@ -72,7 +72,7 @@ public class DownloadDistmapResultIntegrationTest extends RTCommandLineProgramTe
 
     // stop the mini-cluster
     @AfterClass(alwaysRun = true)
-    private void shutdownMiniCluster() {
+    public void shutdownMiniCluster() {
         MiniClusterUtils.stopCluster(cluster);
     }
 

--- a/src/test/java/org/magicdgs/readtools/tools/distmap/ReadsToDistmapIntegrationTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/distmap/ReadsToDistmapIntegrationTest.java
@@ -26,12 +26,24 @@ package org.magicdgs.readtools.tools.distmap;
 
 import org.magicdgs.readtools.RTCommandLineProgramTest;
 
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.MiniClusterUtils;
+import org.broadinstitute.hellbender.utils.text.XReadLines;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
@@ -41,34 +53,54 @@ public class ReadsToDistmapIntegrationTest extends RTCommandLineProgramTest {
     private static final File TEST_TEMP_DIR =
             createTestTempDir(ReadsToDistmapIntegrationTest.class.getSimpleName());
 
+    private MiniDFSCluster cluster;
+    private String clusterOutputFolder;
+
+    // init the cluster and copy the files there
+    @BeforeClass(alwaysRun = true)
+    private void setupMiniCluster() throws Exception {
+        // gets the cluster and create the directory
+        cluster = MiniClusterUtils.getMiniCluster();
+        final Path distmapClusterFolder = IOUtils.getPath(
+                cluster.getFileSystem().getUri().toString()
+                        + "/distmap_input/fastq_paired_end_mapping_bwa/");
+        clusterOutputFolder = distmapClusterFolder.toUri().toString();
+    }
+
+    // stop the mini-cluster
+    @AfterClass(alwaysRun = true)
+    private void shutdownMiniCluster() {
+        MiniClusterUtils.stopCluster(cluster);
+    }
+
     @DataProvider(name = "toDistmap")
     public Object[][] tesReadsToDistmapData() {
         final File expectedPaired = getTestFile("expected_paired.distmap");
         final File expectedSingle = getTestFile("expected_single.distmap");
         return new Object[][] {
-                {"StandardizeReads_paired_SAM",
+                {"ReadsToDistmap_paired_SAM",
                         new ArgumentsBuilder()
                                 .addInput(getTestFile("small.paired.sam"))
                                 .addBooleanArgument("interleaved", true)
                                 .addArgument("rawBarcodeSequenceTags", "BC")
                                 .addArgument("rawBarcodeSequenceTags", "B2"),
                         expectedPaired},
-                {"StandardizeReads_single_SAM",
+                {"ReadsToDistmap_single_SAM",
                         new ArgumentsBuilder()
                                 .addInput(getTestFile("small.single.sam"))
                                 .addArgument("rawBarcodeSequenceTags", "BC")
                                 .addArgument("rawBarcodeSequenceTags", "B2"),
                         expectedSingle},
-                {"StandardizeReads_paired_FASTQ",
+                {"ReadsToDistmap_paired_FASTQ",
                         new ArgumentsBuilder()
                                 .addInput(getTestFile("small_1.illumina.fq"))
                                 .addFileArgument("input2", getTestFile("small_2.illumina.fq")),
                         expectedPaired},
-                {"StandardizeReads_single_FASTQ",
+                {"ReadsToDistmap_single_FASTQ",
                         new ArgumentsBuilder()
                                 .addInput(getTestFile("small_se.illumina.fq")),
                         expectedSingle},
-                {"StandardizeReads_single_SAM_names",
+                {"ReadsToDistmap_single_SAM_names",
                         new ArgumentsBuilder()
                                 .addInput(getTestFile("small.single.name.sam"))
                                 .addBooleanArgument("barcodeInReadName", true),
@@ -76,9 +108,8 @@ public class ReadsToDistmapIntegrationTest extends RTCommandLineProgramTest {
         };
     }
 
-    // expected output should be SAM
     @Test(dataProvider = "toDistmap")
-    public void tesStandardizeReads(final String name, final ArgumentsBuilder args,
+    public void testReadsToDistmapLocal(final String name, final ArgumentsBuilder args,
             final File expectedOutput)
             throws Exception {
         // output is always in
@@ -91,4 +122,60 @@ public class ReadsToDistmapIntegrationTest extends RTCommandLineProgramTest {
         IntegrationTestSpec.assertEqualTextFiles(output, expectedOutput);
     }
 
+    @Test(dataProvider = "toDistmap")
+    public void testReadsToDistmapCluster(final String name, final ArgumentsBuilder args,
+            final File expectedOutput)
+            throws Exception {
+        // output is always in
+        final Path output = IOUtils.getPath(clusterOutputFolder + "/" + name + ".distmap");
+        // add output, and set the quiet level
+        args.addArgument("output", output.toUri().toString());
+        runCommandLine(args);
+
+        // using text file concordance
+        assertEqualTextFiles(output, expectedOutput);
+    }
+
+    @DataProvider
+    public Object[][] blockSizes() {
+        // this are the two block sizes implemented in Distmap for different mappers
+        return new Object[][] {{16777216}, {8388608}};
+    }
+
+    @Test(dataProvider = "blockSizes")
+    public void testHdfsBlockSize(final long blockSize) throws Exception {
+        final org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(clusterOutputFolder, "testHdfsBlockSize-" + blockSize + ".distmap");
+        Assert.assertFalse(cluster.getFileSystem().exists(path), "output already exists");
+
+        final ArgumentsBuilder args = new ArgumentsBuilder()
+                .addInput(getTestFile("small_se.illumina.fq"))
+                .addArgument("output", path.toUri().toString())
+                .addArgument("hdfsBlockSize", Long.toString(blockSize));
+
+        runCommandLine(args);
+
+        // only test if its exists and block sizes
+        Assert.assertTrue(cluster.getFileSystem().exists(path));
+        Assert.assertEquals(cluster.getFileSystem().getFileStatus(path).getBlockSize(), blockSize);
+    }
+
+    // copied from IntegrationTestSpec.assertEqualTextFiles to allow path
+    private static void assertEqualTextFiles(final Path resultPath, final File expectedFile) throws
+            IOException {
+        try (final XReadLines resultReader = new XReadLines(Files.newBufferedReader(resultPath), true, null);
+        final XReadLines expectedReader = new XReadLines(expectedFile)) {
+            final List<String> actualLines = resultReader.readLines().stream()
+                    .collect(Collectors.toList());
+            final List<String> expectedLines = expectedReader.readLines().stream()
+                    .collect(Collectors.toList());
+            //For ease of debugging, we look at the lines first and only then check their counts
+            final int minLen = Math.min(actualLines.size(), expectedLines.size());
+            for (int i = 0; i < minLen; i++) {
+                Assert.assertEquals(actualLines.get(i).toString(), expectedLines.get(i).toString(), "Line number " + i + " (not counting comments)");
+            }
+            Assert.assertEquals(actualLines.size(), expectedLines.size(), "line counts");
+        } catch (IOException e) {
+            Assert.fail(e.getMessage());
+        }
+    }
 }

--- a/src/test/java/org/magicdgs/readtools/tools/distmap/ReadsToDistmapIntegrationTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/distmap/ReadsToDistmapIntegrationTest.java
@@ -58,18 +58,18 @@ public class ReadsToDistmapIntegrationTest extends RTCommandLineProgramTest {
 
     // init the cluster and copy the files there
     @BeforeClass(alwaysRun = true)
-    private void setupMiniCluster() throws Exception {
+    public void setupMiniCluster() throws Exception {
         // gets the cluster and create the directory
         cluster = MiniClusterUtils.getMiniCluster();
         final Path distmapClusterFolder = IOUtils.getPath(
                 cluster.getFileSystem().getUri().toString()
-                        + "/distmap_input/fastq_paired_end_mapping_bwa/");
+                        + "/distmap_input/fastq_paired_end/");
         clusterOutputFolder = distmapClusterFolder.toUri().toString();
     }
 
     // stop the mini-cluster
     @AfterClass(alwaysRun = true)
-    private void shutdownMiniCluster() {
+    public void shutdownMiniCluster() {
         MiniClusterUtils.stopCluster(cluster);
     }
 


### PR DESCRIPTION
Using `MiniDFSCluster` to test Distmap tools. Includes:

* Run all the current test after setting up a mini-cluster
* Tests for download/upload files
* Test for block-size of output when uploading files

Closes #80