### PR TITLE
Honor asynchronious writing in Distmap format

### DIFF
--- a/src/main/java/org/magicdgs/readtools/utils/read/ReadWriterFactory.java
+++ b/src/main/java/org/magicdgs/readtools/utils/read/ReadWriterFactory.java
@@ -30,7 +30,6 @@ import org.magicdgs.readtools.utils.distmap.DistmapGATKWriter;
 import org.magicdgs.readtools.utils.fastq.FastqGATKWriter;
 import org.magicdgs.readtools.utils.read.writer.ReadToolsIOFormat;
 
-import com.google.common.annotations.VisibleForTesting;
 import hdfs.jsr203.HadoopPath;
 import htsjdk.samtools.Defaults;
 import htsjdk.samtools.SAMException;
@@ -45,7 +44,6 @@ import htsjdk.samtools.util.AbstractAsyncWriter;
 import htsjdk.samtools.util.CustomGzipOutputStream;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Md5CalculatingOutputStream;
-import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.AbstractFeatureReader;
 import org.apache.commons.compress.compressors.bzip2.BZip2Utils;
 import org.apache.hadoop.conf.Configuration;

--- a/src/main/java/org/magicdgs/readtools/utils/read/ReadWriterFactory.java
+++ b/src/main/java/org/magicdgs/readtools/utils/read/ReadWriterFactory.java
@@ -30,6 +30,7 @@ import org.magicdgs.readtools.utils.distmap.DistmapGATKWriter;
 import org.magicdgs.readtools.utils.fastq.FastqGATKWriter;
 import org.magicdgs.readtools.utils.read.writer.ReadToolsIOFormat;
 
+import com.google.common.annotations.VisibleForTesting;
 import hdfs.jsr203.HadoopPath;
 import htsjdk.samtools.Defaults;
 import htsjdk.samtools.SAMException;
@@ -430,18 +431,10 @@ public final class ReadWriterFactory {
             underlyingWriter.addRead(item);
         }
 
-        /**
-         * Close the underlying writing.
-         * @throws RuntimeIOException if there is an I/O problem while closing.
-         */
+        /** Close the underlying writer. */
         @Override
         protected void synchronouslyClose() {
-            try {
-                underlyingWriter.close();
-            } catch (final IOException e) {
-                // TODO: maybe use an user exception?
-                throw new RuntimeIOException(e);
-            }
+            closeWriter(this.underlyingWriter);
         }
 
         @Override

--- a/src/test/java/org/magicdgs/readtools/utils/distmap/DistmapGATKWriterUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/distmap/DistmapGATKWriterUnitTest.java
@@ -80,6 +80,18 @@ public class DistmapGATKWriterUnitTest extends RTBaseTest {
         IntegrationTestSpec.assertEqualTextFiles(actual, expected);
     }
 
+    @Test(dataProvider = "distmapFiles")
+    public void testAsyncWriter(final File expected, final boolean paired) throws Exception {
+        final File actual = new File(TEST_TMP_DIR, "async." + expected.getName());
+        try (final GATKReadWriter writer = new ReadWriterFactory()
+                .setUseAsyncIo(true)
+                .createDistmapWriter(actual.getAbsolutePath(), paired)) {
+            writer.addRead(READ_1);
+            writer.addRead(READ_2);
+        }
+        IntegrationTestSpec.assertEqualTextFiles(actual, expected);
+    }
+
     @Test(expectedExceptions = DistmapException.class)
     public void testCloseBroken() throws Exception {
         final File broken = new File(TEST_TMP_DIR, "broken.distmap");


### PR DESCRIPTION
ReadWriterFactory does not write asynchronously Distmap output even if this behavior is requested. This solves that issue.