### PR TITLE
Fix broken javadoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,16 +34,16 @@ install:
 
 script:
     - if [[ $TYPE == shadow ]]; then
-          ./gradlew shadowJar;
-          java -jar ./build/libs/ReadTools.jar --version;
-          java -jar ./build/libs/ReadTools.jar StandardizeReads --version;
+          ./gradlew shadowJar &&
+          java -jar ./build/libs/ReadTools.jar --version &&
+          java -jar ./build/libs/ReadTools.jar StandardizeReads --version &&
           java -jar ./build/libs/ReadTools.jar StandardizeReads --verbosity ERROR --input ./src/test/resources/org/magicdgs/readtools/tools/conversion/StandardizeReads/small_se.illumina.fq --output ./tmp/test.sam;
       elif [[ $TYPE == test ]]; then
           ./gradlew jacocoTestReport;
       elif [[ $TYPE == documentation ]]; then
-          rvm use 2.4.0 --install --binary --fuzzy;
-          bundle install --gemfile docs/Gemfile;
-          ./gradlew javadoc readtoolsDoc;
+          rvm use 2.4.0 --install --binary --fuzzy &&
+          bundle install --gemfile docs/Gemfile &&
+          ./gradlew javadoc readtoolsDoc &&
           ./scripts/test_documentation.sh;
       else
           echo "Test type not recognized $TYPE";

--- a/src/main/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandler.java
+++ b/src/main/java/org/magicdgs/readtools/documentation/RTHelpDocWorkUnitHandler.java
@@ -87,8 +87,8 @@ public class RTHelpDocWorkUnitHandler extends DefaultDocWorkUnitHandler {
      * Uses different descriptions depending on the work unit content. The first non-empty of:
      *
      * 1. Default method to capture the javadoc description.
-     * 2. {@link CommandLineProgramProperties#summary()} for tools
-     * 3. {@link org.broadinstitute.barclay.help.DocumentedFeature#summary()}
+     * 2. {@link CommandLineProgramProperties#summary()} for tools.
+     * 3. {@link org.broadinstitute.barclay.help.DocumentedFeature} summary.
      *
      * Otherwise, the description will be empty.
      */


### PR DESCRIPTION
Due to an error in the Java's code for javadoc generation, an annotation method could not be accessed if it has a default value. This commit fixes the usage of this broken feature in our javadoc.

It also fixes the travis script for testing several commands, which before this commit was only failing if the last command does.