### PR TITLE
Override Main.handleUserException

### DIFF
--- a/src/main/java/org/magicdgs/readtools/Main.java
+++ b/src/main/java/org/magicdgs/readtools/Main.java
@@ -108,7 +108,7 @@ public final class Main extends org.broadinstitute.hellbender.Main {
 
     /**
      * Prints in {@link #exceptionOutput} the decorated exception as an user error.
-     * In addition, prints the stack trace if the debug mode is enabled.
+     * In addition, prints the stack-trace if the debug mode is enabled.
      */
     @Override
     protected void handleUserException(Exception e) {
@@ -120,7 +120,8 @@ public final class Main extends org.broadinstitute.hellbender.Main {
      * Prints in {@link #exceptionOutput} the decorated exception as an unexpected error.
      *
      * In addition, it adds a note pointing to the issue tracker
-     * ({@link RTHelpConstants#ISSUE_TRACKER})
+     * ({@link RTHelpConstants#ISSUE_TRACKER}) and prints the stack-trace if the debug mode is
+     * enabled.
      */
     @Override
     protected void handleNonUserException(final Exception e) {

--- a/src/main/java/org/magicdgs/readtools/Main.java
+++ b/src/main/java/org/magicdgs/readtools/Main.java
@@ -107,10 +107,20 @@ public final class Main extends org.broadinstitute.hellbender.Main {
     }
 
     /**
-     * Prints in {@link System#err} the decorated exception as an unexpected error.
+     * Prints in {@link #exceptionOutput} the decorated exception as an user error.
+     * In addition, prints the stack trace if the debug mode is enabled.
+     */
+    @Override
+    protected void handleUserException(Exception e) {
+        printDecoratedExceptionMessage(exceptionOutput, e, "A USER ERROR has occurred: ");
+        printStackTrace(e);
+    }
+
+    /**
+     * Prints in {@link #exceptionOutput} the decorated exception as an unexpected error.
      *
      * In addition, it adds a note pointing to the issue tracker
-     * ({@link RTHelpConstants#ISSUE_TRACKER}).
+     * ({@link RTHelpConstants#ISSUE_TRACKER})
      */
     @Override
     protected void handleNonUserException(final Exception e) {
@@ -118,9 +128,17 @@ public final class Main extends org.broadinstitute.hellbender.Main {
         exceptionOutput
                 .println("Please, search for this error in our issue tracker or post a new one:");
         exceptionOutput.println("\t" + RTHelpConstants.ISSUE_TRACKER);
-        // only log the stack-trace for DEBUG mode
+        printStackTrace(e);
+    }
+
+    /**
+     * Prints the stack-trace into {@link #exceptionOutput} only if
+     * {@link htsjdk.samtools.util.Log.LogLevel#DEBUG} is enabled.
+     */
+    @VisibleForTesting
+    protected final void printStackTrace(final Exception e) {
         if (Log.isEnabled(Log.LogLevel.DEBUG)) {
-            e.printStackTrace();
+            e.printStackTrace(exceptionOutput);
         }
     }
 

--- a/src/test/java/org/magicdgs/readtools/MainUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/MainUnitTest.java
@@ -54,7 +54,7 @@ public class MainUnitTest extends RTBaseTest {
     @Test(dataProvider = "resultsToHandle")
     public void testHandleResult(final Object result, final String printedResult) throws Exception {
         final Main main = new Main();
-        try(final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
                 final PrintStream printStream = new PrintStream(outputStream)) {
             main.resultOutput = printStream;
             main.handleResult(result);
@@ -82,7 +82,7 @@ public class MainUnitTest extends RTBaseTest {
     public void testHandleNonUserException() throws Exception {
         final String message = "this is a test exception";
         final Main main = new Main();
-        try(final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
                 final PrintStream printStream = new PrintStream(outputStream)) {
             main.exceptionOutput = printStream;
             main.handleNonUserException(new RuntimeException(message));
@@ -97,12 +97,12 @@ public class MainUnitTest extends RTBaseTest {
     @DataProvider(name = "printVersionArgs")
     public Object[][] getArgumentsForPrintOnlyVersionTest() {
         return new Object[][] {
-                {new String[]{"--version"}, true},
-                {new String[]{"-v"}, true},
-                {new String[]{"ToolName"}, false},
-                {new String[]{"--version", "--other"}, false},
-                {new String[]{"-v", "--other"}, false},
-                {new String[]{"ToolName", "--version"}, false}
+                {new String[] {"--version"}, true},
+                {new String[] {"-v"}, true},
+                {new String[] {"ToolName"}, false},
+                {new String[] {"--version", "--other"}, false},
+                {new String[] {"-v", "--other"}, false},
+                {new String[] {"ToolName", "--version"}, false}
         };
     }
 


### PR DESCRIPTION
Overrides the handleUserException for avoid GATK's message referring to their system property and the gatk-launch wrapper script while not printing the stack-trace on user exception.

Now the stack-trace is printed for UserExceptions if the DEBUG mode is enabled, the same as the unexpected errors.

Closes #297 