### PR TITLE
Add 2L.fragment.dict to walkthrough data

### DIFF
--- a/docs/walkthrough/data/2L.fragment.dict
+++ b/docs/walkthrough/data/2L.fragment.dict
@@ -1,0 +1,2 @@
+@HD	VN:1.5
+@SQ	SN:2L	LN:59940	M5:257b291d9a9eeca78f3c7b09211fdd26	UR:file:/Users/daniel/workspaces/ReadTools/docs/walkthrough/data/2L.fragment.fa

--- a/docs/walkthrough/data/checksum
+++ b/docs/walkthrough/data/checksum
@@ -41,3 +41,4 @@ e7f38e435c884a2a9137a9dcd0fcf4d7 standard.single_index.SE.sam
 bb271b5214639b819e1a6cea13d862c7 standard.single_index.paired.bam
 33639bd45dadb8042780817be542dec4 standard.single_index.paired.cram
 9df1d0aecbebb3857b4ce87d5d0e52eb standard.single_index.paired.sam
+fa9ddafe406cccab343a043eb101c1af 2L.fragment.dict

--- a/docs/walkthrough/walkthrough_data.md
+++ b/docs/walkthrough/walkthrough_data.md
@@ -87,9 +87,11 @@ the theme. Additionally, keep the column heading titles short. -->
 
 Additional required data beside of read sources:
 
-* [2L.fragment.fa]({{walkthrough_folder}}2L.fragment.fa)/
-  [2L.fragment.fa.fai]({{walkthrough_folder}}2L.fragment.fa.fai): 
-  Indexed FASTA file for use with mapped reads and CRAM sources.
+* [2L.fragment.fa]({{walkthrough_folder}}2L.fragment.fa): 
+  FASTA file for use with mapped reads and CRAM sources. The folder 
+  also includes the following files needed for its use in ReadTools:
+  - [2L.fragment.fa.fai]({{walkthrough_folder}}2L.fragment.fa.fai): index file
+  - [2L.fragment.dict]({{walkthrough_folder}}2L.fragment.dict): dictionary (SAM header)
 * [dual.barcodes]({{walkthrough_folder}}dual.barcodes): barcode file 
   for samples with dual-indexing.
 * [single.barcodes]({{walkthrough_folder}}single.barcodes): barcode 


### PR DESCRIPTION
Required for use the FASTA file in the GATK framework directly, without running `CreateSequenceDictionary`.