### PR TITLE
Get version from Barclay's index.yml in online help

### DIFF
--- a/docs/_data/index.yml
+++ b/docs/_data/index.yml
@@ -1,6 +1,6 @@
 ReadTools:
-  - version: 1.0.0
-  - timestamp: 19-58-2017 02:58:19
+  version: 1.0.0
+  timestamp: 19-58-2017 02:58:19
 
 tools:
   - group: Diagnostics and Quality Control Tools

--- a/docs/_data/sidebars/home_sidebar.yml
+++ b/docs/_data/sidebars/home_sidebar.yml
@@ -3,7 +3,8 @@
 entries:
 - title: Sidebar
   product: ReadTools
-  version: 1.0.0
+  # This is substituted in the sidebar and wherever it is used by teh index.yml corresponding data
+  version: "site.data.index.ReadTools.version"
   folders:
 
   - title: ReadTools

--- a/docs/_data/topnav.yml
+++ b/docs/_data/topnav.yml
@@ -1,5 +1,6 @@
 ## Topnav single links
 ## if you want to list an external url, use external_url instead of url. the theme will apply a different link base.
+## urls will parse automatically the site.data.index.ReadTools.version to being in sync with the version
 topnav:
 - title: Topnav
   items:
@@ -10,10 +11,9 @@ topnav:
 topnav_dropdowns:
 - title: Topnav dropdowns
   folders:
-    # TODO: generate automatically this links!!
     - title: Download
       folderitems:
         - title: Executable Jar
-          external_url: https://github.com/magicDGS/ReadTools/releases/download/1.0.0/ReadTools.jar
+          external_url: https://github.com/magicDGS/ReadTools/releases/download/site.data.index.ReadTools.version/ReadTools.jar
         - title: Repository zip
-          external_url: https://github.com/magicDGS/ReadTools/archive/1.0.0.tar.gz
+          external_url: https://github.com/magicDGS/ReadTools/archive/site.data.index.ReadTools.version.tar.gz

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -1,7 +1,7 @@
 {% include custom/sidebarconfigs.html %}
 
 <ul id="mysidebar" class="nav">
-    <li class="sidebarTitle">{{sidebar[0].product}} {{sidebar[0].version}}</li>
+    <li class="sidebarTitle">{{sidebar[0].product}} {{sidebar[0].version | replace: 'site.data.index.ReadTools.version', site.data.index.ReadTools.version}}</li>
     {% for entry in sidebar %}
     {% for folder in entry.folders %}
     {% if folder.output contains "web" %}

--- a/docs/_includes/topnav.html
+++ b/docs/_includes/topnav.html
@@ -18,11 +18,11 @@
                 {% for entry in site.data.topnav.topnav %}
                 {% for item in entry.items %}
                 {% if item.external_url %}
-                <li><a href="{{item.external_url}}" target="_blank">{{item.title}}</a></li>
+                <li><a href="{{item.external_url | replace: 'site.data.index.ReadTools.version', site.data.index.ReadTools.version}}" target="_blank">{{item.title}}</a></li>
                 {% elsif page.url contains item.url %}
-                <li class="active"><a href="{{item.url | remove: "/"}}">{{item.title}}</a></li>
+                <li class="active"><a href="{{item.url | remove: "/" | replace: 'site.data.index.ReadTools.version', site.data.index.ReadTools.version}}">{{item.title}}</a></li>
                 {% else %}
-                <li><a href="{{item.url | remove: "/"}}">{{item.title}}</a></li>
+                <li><a href="{{item.url | remove: "/" | replace: 'site.data.index.ReadTools.version', site.data.index.ReadTools.version}}">{{item.title}}</a></li>
                 {% endif %}
                 {% endfor %}
                 {% endfor %}
@@ -35,11 +35,11 @@
                     <ul class="dropdown-menu">
                         {% for folderitem in folder.folderitems %}
                         {% if folderitem.external_url %}
-                        <li><a href="{{folderitem.external_url}}" target="_blank">{{folderitem.title}}</a></li>
+                        <li><a href="{{folderitem.external_url | replace: 'site.data.index.ReadTools.version', site.data.index.ReadTools.version}}" target="_blank">{{folderitem.title}}</a></li>
                         {% elsif page.url contains folderitem.url %}
-                        <li class="dropdownActive"><a href="{{folderitem.url |  remove: "/"}}">{{folderitem.title}}</a></li>
+                        <li class="dropdownActive"><a href="{{folderitem.url | remove: "/" | replace: 'site.data.index.ReadTools.version', site.data.index.ReadTools.version}}">{{folderitem.title}}</a></li>
                         {% else %}
-                        <li><a href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
+                        <li><a href="{{folderitem.url | remove: "/" | replace: 'site.data.index.ReadTools.version', site.data.index.ReadTools.version}}">{{folderitem.title}}</a></li>
                         {% endif %}
                         {% endfor %}
                     </ul>

--- a/src/main/resources/org/magicdgs/readtools/documentation/generic.index.template.yml
+++ b/src/main/resources/org/magicdgs/readtools/documentation/generic.index.template.yml
@@ -16,8 +16,8 @@
     </#list>
 </#macro>
 ReadTools:
-  - version: ${version}
-  - timestamp: ${timestamp}
+  version: ${version}
+  timestamp: ${timestamp}
 
 <#list seq as supercat>
 ${supercat}:

--- a/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/index.yml
+++ b/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/index.yml
@@ -1,6 +1,6 @@
 ReadTools:
-  - version: 11.1
-  - timestamp: 2016/01/01 01:01:01
+  version: 11.1
+  timestamp: 2016/01/01 01:01:01
 
 tools:
   


### PR DESCRIPTION
For keep the versioning consistent across the online help, the current templates include:

* Update index.yml and template for easier retrieval of version and timestamp from Jekyll.
* Replace the full data address in every sidebar.yml and every url in topnav.yml for the version in index.yml

Closes #245 
Closes #265