### PR TITLE
Update GATK and HTSJDK dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,9 +53,6 @@ final gatkVersion = '4.beta.5-55-g577c763-SNAPSHOT'
 final htsjdkVersion = '2.12.0'
 final testNGVersion = '6.11'
 final mockitoVersion = '2.7.19'
-// TODO: this is a workaround for https://github.com/broadinstitute/gatk/issues/3532
-// TODO: and should be removed in the future
-final gklWorkingVersion = '0.5.2'
 
 // Get the jdk files we need to run javaDoc. We need to use these during compile, testCompile,
 // test execution, and readtoolsDoc generation, but we don't want them as part of the runtime
@@ -79,8 +76,6 @@ configurations.all {
         force 'org.testng:testng:' + testNGVersion
         // be sure that mockito is in the same version for our tests
         force 'org.mockito:mockito-core:' + mockitoVersion
-        // TODO: this force should be removed
-        force 'com.intel.gkl:gkl:' + gklWorkingVersion
     }
 }
 
@@ -91,11 +86,6 @@ dependencies {
         exclude module: 'jgrapht' // this is not required
     }
     compile group: 'com.github.samtools', name: 'htsjdk', version: htsjdkVersion
-
-    // TODO: this dependency should be the one from GATK4
-    compile('com.intel.gkl:gkl:' + gklWorkingVersion) {
-        exclude module: 'htsjdk'
-    }
 
     // compilation for testing
     testCompile 'org.testng:testng:' + testNGVersion

--- a/build.gradle
+++ b/build.gradle
@@ -49,8 +49,8 @@ repositories {
     }
 }
 // versions for the dependencies to resolve conflicts
-final gatkVersion = '4.beta.4-2-g1edf1b6-SNAPSHOT'
-final htsjdkVersion = '2.11.0-4-g958dc6e-SNAPSHOT'
+final gatkVersion = '4.beta.5-55-g577c763-SNAPSHOT'
+final htsjdkVersion = '2.12.0'
 final testNGVersion = '6.11'
 final mockitoVersion = '2.7.19'
 // TODO: this is a workaround for https://github.com/broadinstitute/gatk/issues/3532

--- a/src/test/java/org/magicdgs/readtools/tools/trimming/TrimAndFilterPipelineUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/trimming/TrimAndFilterPipelineUnitTest.java
@@ -577,32 +577,6 @@ public class TrimAndFilterPipelineUnitTest extends RTBaseTest {
     }
 
     @Test(dataProvider = "trimmersAndFilters")
-    public void testGetPipeline(final List<TrimmingFunction> defaultTrimmers,
-            final List<ReadFilter> userFilters) throws Exception {
-        // set up the GATKReadFilterPluginDescriptor -> defaults null because they does not matter
-        final GATKReadFilterPluginDescriptor filterDescriptor =
-                new GATKReadFilterPluginDescriptor(null);
-        // this is like parsing the arguments with Barclay
-        userFilters.stream().map(ReadFilter::getClass).forEach(rf -> {
-            filterDescriptor.userArgs.getUserEnabledReadFilterNames().add(rf.getSimpleName());
-            try {
-                filterDescriptor.getInstance(rf);
-            } catch (IllegalAccessException | InstantiationException e) {
-                Assert.fail(e.getMessage());
-            }
-        });
-
-        // get the trimming pipeline arguments
-        final TrimAndFilterPipeline pipeline = TrimAndFilterPipeline.fromPluginDescriptors(
-                new TrimmerPluginDescriptor(defaultTrimmers), filterDescriptor);
-
-        // check that the pipeline contains the same number of trimmers
-        Assert.assertEquals(pipeline.getTrimmingStats().size(), defaultTrimmers.size());
-        // and the same number of filters + 1 (completely trimmed)
-        Assert.assertEquals(pipeline.getFilterStats().size(), userFilters.size() + 1);
-    }
-
-    @Test(dataProvider = "trimmersAndFilters")
     public void testGetPipelineCompatibleWithGATKReadFilterPluginDescriptor(
             final List<TrimmingFunction> defaultTrimmers,
             final List<ReadFilter> defaultFilters) throws Exception {


### PR DESCRIPTION
* Update GATK and HTSJDK dependencies
* Refactor `TrimAndFilterPipeline` to fix compilation problems
* Use default GKL version from GATK

Closes #313  