### PR TITLE
Fix documentation generation for argument containers

### DIFF
--- a/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/DocumentedFeatureWithJavadoc.json
+++ b/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/DocumentedFeatureWithJavadoc.json
@@ -1,5 +1,6 @@
 {
   "summary": "Inline summary",
+  "arguments": [],
   "description": "Description in javadoc",
   "name": "DocumentedFeatureWithJavadoc",
   "group": "Inline groupName"

--- a/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/DocumentedFeatureWithoutJavadoc.json
+++ b/src/test/resources/org/magicdgs/readtools/documentation/RTHelpDoclet/DocumentedFeatureWithoutJavadoc.json
@@ -1,5 +1,6 @@
 {
   "summary": "Inline summary",
+  "arguments": [],
   "description": "Inline summary",
   "name": "DocumentedFeatureWithoutJavadoc",
   "group": "Inline groupName"


### PR DESCRIPTION
Argument containers such as ReadFilters or Trimmers contain arguments that should be documented, but Barclay added a fix to do not require non-arg constructor that breaks that behaviour even if they do.

This PR adds a hack that fix this broken behaviour.