### PR TITLE
Support CRAM input with java.nio.Path reference

### DIFF
--- a/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTInputArgumentCollection.java
+++ b/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTInputArgumentCollection.java
@@ -35,8 +35,8 @@ import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.hellbender.utils.read.ReadConstants;
 
-import java.io.File;
 import java.io.Serializable;
+import java.nio.file.Path;
 
 /**
  * Argument collection for ReaTools input files.
@@ -74,7 +74,7 @@ public final class RTInputArgumentCollection implements Serializable {
     private Supplier<RTDataSource> source = null;
 
     // creates the reader
-    private ReadReaderFactory getReaderFactory(final File referenceFileName) {
+    private ReadReaderFactory getReaderFactory(final Path referenceFileName) {
         return new ReadReaderFactory()
                 .setReferenceSequence(referenceFileName)
                 .setValidationStringency(readValidationStringency);
@@ -85,7 +85,7 @@ public final class RTInputArgumentCollection implements Serializable {
      *
      * @param referenceFileName the reference file for CRAM inputs. May be {@code null}.
      */
-    public RTDataSource getDataSource(final File referenceFileName) {
+    public RTDataSource getDataSource(final Path referenceFileName) {
         RTDataSource.setReadReaderFactory(getReaderFactory(referenceFileName));
         if (source == null) {
             if (inputPair != null) {

--- a/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputArgumentCollection.java
+++ b/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputArgumentCollection.java
@@ -35,7 +35,6 @@ import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.GATKReadWriter;
 
-import java.io.File;
 import java.io.Serializable;
 import java.nio.file.Path;
 import java.util.function.Supplier;
@@ -58,7 +57,7 @@ public abstract class RTOutputArgumentCollection implements Serializable {
      *
      * Note: this factory may be used for extra outputs that are not part of the argument
      * collection. For instance, if a discarded output is requested. Otherwise, use
-     * {@link #outputWriter(SAMFileHeader, Supplier, boolean, File)}.
+     * {@link #outputWriter(SAMFileHeader, Supplier, boolean, Path)}.
      *
      * Implementations should call the super method to honor the common arguments.
      */
@@ -84,11 +83,11 @@ public abstract class RTOutputArgumentCollection implements Serializable {
      */
     public final GATKReadWriter outputWriter(final SAMFileHeader header,
             final Supplier<SAMProgramRecord> programRecord, final boolean presorted,
-            final File referenceFile) {
+            final Path referenceFile) {
         Utils.nonNull(header, "null header");
         updateHeader(header, programRecord);
         validateUserOutput();
-        return createWriter(getWriterFactory().setReferenceFile(referenceFile),
+        return createWriter(getWriterFactory().setReferencePath(referenceFile),
                 header, presorted);
     }
 

--- a/src/main/java/org/magicdgs/readtools/engine/ReadToolsWalker.java
+++ b/src/main/java/org/magicdgs/readtools/engine/ReadToolsWalker.java
@@ -33,10 +33,11 @@ import htsjdk.samtools.util.Locatable;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.hellbender.engine.ProgressMeter;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import scala.Tuple2;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.function.Consumer;
 import java.util.stream.StreamSupport;
 
@@ -59,7 +60,7 @@ public abstract class ReadToolsWalker extends ReadToolsProgram {
     private double secondsBetweenProgressUpdates = ProgressMeter.DEFAULT_SECONDS_BETWEEN_UPDATES;
 
     @Argument(fullName = RTStandardArguments.REFERENCE_LONG_NAME, shortName = RTStandardArguments.REFERENCE_SHORT_NAME, doc = "Reference sequence file. Required for CRAM input.", optional = true, common = true)
-    private File referenceFile = null;
+    private String referencePath = null;
 
     @ArgumentCollection
     private RTInputArgumentCollection inputArgumentCollection = new RTInputArgumentCollection();
@@ -85,7 +86,7 @@ public abstract class ReadToolsWalker extends ReadToolsProgram {
     protected final void onStartup() {
         super.onStartup();
         progressMeter = new ProgressMeter(secondsBetweenProgressUpdates);
-        dataSource = inputArgumentCollection.getDataSource(referenceFile);
+        dataSource = inputArgumentCollection.getDataSource(getReferencePath());
         logger.info("Input source quality encoding: {}", dataSource.getOriginalQualityEncoding());
     }
 
@@ -215,8 +216,8 @@ public abstract class ReadToolsWalker extends ReadToolsProgram {
     public void closeTool() { }
 
     /** Gets the reference file if provided; {@code null} otherwise. */
-    public final File getReferenceFile() {
-        return referenceFile;
+    public final Path getReferencePath() {
+        return referencePath == null ? null : IOUtils.getPath(referencePath);
     }
 
     /** Rerturns {@code true} if the input is paired. */

--- a/src/main/java/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode.java
+++ b/src/main/java/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcode.java
@@ -133,13 +133,13 @@ public final class AssignReadGroupByBarcode extends ReadToolsWalker {
 
         // output the writer
         writer = outputBamArgumentCollection.outputWriter(headerForWriter,
-                () -> getProgramRecord(headerForWriter), true, getReferenceFile()
+                () -> getProgramRecord(headerForWriter), true, getReferencePath()
         );
 
         // discarded writer
         discardedWriter = (keepDiscarded)
                 ? discardedWriter = outputBamArgumentCollection.getWriterFactory()
-                .setReferenceFile(getReferenceFile())
+                .setReferencePath(getReferencePath())
                 .createWriter(outputBamArgumentCollection
                                 .getOutputNameWithSuffix(RTDefaults.DISCARDED_OUTPUT_SUFFIX),
                         getHeaderForReads(), true)

--- a/src/main/java/org/magicdgs/readtools/tools/conversion/ReadsToFastq.java
+++ b/src/main/java/org/magicdgs/readtools/tools/conversion/ReadsToFastq.java
@@ -84,7 +84,7 @@ public final class ReadsToFastq extends ReadToolsWalker {
             headerFromReads.setSortOrder(SAMFileHeader.SortOrder.queryname);
         }
         writer = outputBamArgumentCollection.outputWriter(headerFromReads,
-                () -> getProgramRecord(headerFromReads), true, getReferenceFile()
+                () -> getProgramRecord(headerFromReads), true, getReferencePath()
         );
     }
 

--- a/src/main/java/org/magicdgs/readtools/tools/conversion/StandardizeReads.java
+++ b/src/main/java/org/magicdgs/readtools/tools/conversion/StandardizeReads.java
@@ -115,7 +115,7 @@ public final class StandardizeReads extends ReadToolsWalker {
     public void onTraversalStart() {
         final SAMFileHeader headerFromReads = getHeaderForReads();
         writer = outputBamArgumentCollection.outputWriter(headerFromReads,
-                () -> getProgramRecord(headerFromReads), true, getReferenceFile()
+                () -> getProgramRecord(headerFromReads), true, getReferencePath()
         );
     }
 

--- a/src/main/java/org/magicdgs/readtools/tools/distmap/DistmapPartDownloader.java
+++ b/src/main/java/org/magicdgs/readtools/tools/distmap/DistmapPartDownloader.java
@@ -32,6 +32,8 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMProgramRecord;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.ValidationStringency;
+import htsjdk.samtools.cram.ref.CRAMReferenceSource;
+import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.util.IOUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -54,6 +56,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -74,7 +77,7 @@ final class DistmapPartDownloader {
     private double secondsBetweenProgressUpdates = ProgressMeter.DEFAULT_SECONDS_BETWEEN_UPDATES;
 
     @Argument(fullName = RTStandardArguments.REFERENCE_LONG_NAME, shortName = RTStandardArguments.REFERENCE_SHORT_NAME, doc = "Reference sequence file. Required for CRAM input/output.", optional = true, common = true)
-    private File referenceFile = null;
+    private String referenceFile = null;
 
     @ArgumentCollection
     private RTOutputArgumentCollection outputArgumentCollection =
@@ -104,11 +107,24 @@ final class DistmapPartDownloader {
 
     private SamReaderFactory getSamReaderFactory() {
         if (factory == null) {
+            // TODO - a method for set a Path reference sequence should be included in HTSJDK
+            // TODO - this should be changed to the Path setter in HTSJDK (https://github.com/samtools/htsjdk/pull/1005)
+            final CRAMReferenceSource source = new ReferenceSource(getReferencePath());
             factory = SamReaderFactory.makeDefault()
-                    .referenceSequence(referenceFile)
+                    .referenceSource(source)
                     .validationStringency(readValidationStringency);
         }
         return factory;
+    }
+
+    // reference path constructed on demand
+    private Path referencePath = null;
+
+    private Path getReferencePath() {
+        if (referencePath == null && referenceFile != null) {
+            referencePath = IOUtils.getPath(referenceFile);
+        }
+        return referencePath;
     }
 
     // helper method to construct always in the same way a progress meter
@@ -157,7 +173,7 @@ final class DistmapPartDownloader {
 
         writeReads(toMerge,
                 outputArgumentCollection.outputWriter(header, () -> programRecord.apply(header),
-                        presorted, referenceFile),
+                        presorted, getReferencePath()),
                 mergingProgress);
 
         toMerge.close();

--- a/src/main/java/org/magicdgs/readtools/tools/distmap/DistmapPartDownloader.java
+++ b/src/main/java/org/magicdgs/readtools/tools/distmap/DistmapPartDownloader.java
@@ -56,7 +56,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 

--- a/src/main/java/org/magicdgs/readtools/tools/trimming/TrimReads.java
+++ b/src/main/java/org/magicdgs/readtools/tools/trimming/TrimReads.java
@@ -162,12 +162,12 @@ public final class TrimReads extends ReadToolsWalker {
 
         // setup the writer
         writer = outputBamArgumentCollection.outputWriter(header,
-                () -> getProgramRecord(header), true, getReferenceFile()
+                () -> getProgramRecord(header), true, getReferencePath()
         );
 
         if (keepDiscarded) {
             discardedWriter = outputBamArgumentCollection.getWriterFactory()
-                    .setReferenceFile(getReferenceFile())
+                    .setReferencePath(getReferencePath())
                     .createWriter(outputBamArgumentCollection
                                     .getOutputNameWithSuffix(RTDefaults.DISCARDED_OUTPUT_SUFFIX),
                             getHeaderForReads(), true);

--- a/src/main/java/org/magicdgs/readtools/utils/read/ReadReaderFactory.java
+++ b/src/main/java/org/magicdgs/readtools/utils/read/ReadReaderFactory.java
@@ -78,6 +78,7 @@ public class ReadReaderFactory {
     public ReadReaderFactory setReferenceSequence(final Path referenceSequence) {
         // TODO - this should use the setter in HTSJDK (version >= 2.13.0)
         // TODO - this is a hack using the CRAMReferenceSource instead
+        // TODO - (https://github.com/magicDGS/ReadTools/issues/375)
         final CRAMReferenceSource source = new ReferenceSource(referenceSequence);
         samFactory.referenceSource(source);
         return this;

--- a/src/main/java/org/magicdgs/readtools/utils/read/ReadReaderFactory.java
+++ b/src/main/java/org/magicdgs/readtools/utils/read/ReadReaderFactory.java
@@ -28,6 +28,8 @@ import htsjdk.samtools.SamInputResource;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.ValidationStringency;
+import htsjdk.samtools.cram.ref.CRAMReferenceSource;
+import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.fastq.FastqReader;
 import org.broadinstitute.hellbender.exceptions.UserException;
 
@@ -73,8 +75,11 @@ public class ReadReaderFactory {
     }
 
     /** Set the reference sequence for reading. */
-    public ReadReaderFactory setReferenceSequence(final File referenceFile) {
-        samFactory.referenceSequence(referenceFile);
+    public ReadReaderFactory setReferenceSequence(final Path referenceSequence) {
+        // TODO - this should use the setter in HTSJDK (version >= 2.13.0)
+        // TODO - this is a hack using the CRAMReferenceSource instead
+        final CRAMReferenceSource source = new ReferenceSource(referenceSequence);
+        samFactory.referenceSource(source);
         return this;
     }
 

--- a/src/main/java/org/magicdgs/readtools/utils/read/ReadWriterFactory.java
+++ b/src/main/java/org/magicdgs/readtools/utils/read/ReadWriterFactory.java
@@ -161,6 +161,7 @@ public final class ReadWriterFactory {
     /** Sets the reference file. This is required for CRAM writers. */
     public ReadWriterFactory setReferencePath(final Path referencePath) {
         logger.debug("Reference file for FASTQ/Distmap writers is ignored");
+        // TODO - this should set the reference Path in the samFactory (https://github.com/magicDGS/ReadTools/issues/376)
         this.referencePath = referencePath;
         return this;
     }
@@ -214,8 +215,8 @@ public final class ReadWriterFactory {
         }
     }
 
-    // TODO - this will blow up if the java.nio.Path is not a file and the output is CRAM
-    // TODO - it requires an HTSJDK change not yet in the basecode (https://github.com/samtools/htsjdk/pull/1005)
+    // TODO - this will blow up if the java.nio.Path is not a file and the output is CRAM (https://github.com/magicDGS/ReadTools/issues/376)
+    // TODO - it requires an HTSJDK change not yet in their codebase (https://github.com/samtools/htsjdk/pull/1005)
     private File getReferenceAsFile() {
         try {
             return (referencePath == null) ? null : referencePath.toFile();

--- a/src/test/java/org/magicdgs/readtools/engine/RTDataSourceUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/engine/RTDataSourceUnitTest.java
@@ -84,7 +84,7 @@ public class RTDataSourceUnitTest extends RTBaseTest {
         // this allows CRAM tests by providing a FASTQ file to the data source
         RTDataSource.setReadReaderFactory(new ReadReaderFactory()
                 .setReferenceSequence(TestResourcesUtils
-                        .getWalkthroughDataFile("2L.fragment.fa")));
+                        .getWalkthroughDataFile("2L.fragment.fa").toPath()));
     }
 
     @AfterClass

--- a/src/test/java/org/magicdgs/readtools/engine/ReadToolsWalkerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/engine/ReadToolsWalkerUnitTest.java
@@ -56,7 +56,10 @@ public class ReadToolsWalkerUnitTest extends RTCommandLineProgramTest {
         return new Object[][] {
                 {Arrays.asList("-I", TestResourcesUtils.getWalkthroughDataFile("standard.single_index.SE.sam").getAbsolutePath()), 103, false},
                 {Arrays.asList("-I", TestResourcesUtils.getWalkthroughDataFile("legacy.single_index.paired_1.fq").getAbsolutePath(),
-                        "-I2", TestResourcesUtils.getWalkthroughDataFile("legacy.single_index.paired_2.fq").getAbsolutePath()), 206, true}
+                        "-I2", TestResourcesUtils.getWalkthroughDataFile("legacy.single_index.paired_2.fq").getAbsolutePath()), 206, true},
+                // test also CRAM with reference
+                {Arrays.asList("-I", TestResourcesUtils.getWalkthroughDataFile("standard.dual_index.SE.cram").getAbsolutePath(),
+                        "-R", TestResourcesUtils.getWalkthroughDataFile("2L.fragment.fa").getAbsolutePath()), 103, false}
         };
     }
 

--- a/src/test/java/org/magicdgs/readtools/engine/sourcehandler/ReadsSourceHandlerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/engine/sourcehandler/ReadsSourceHandlerUnitTest.java
@@ -57,7 +57,7 @@ public class ReadsSourceHandlerUnitTest extends RTBaseTest {
 
     // this is the factory for tests, including reference sequence for CRAM
     private final ReadReaderFactory FACTORY_FOR_TEST = new ReadReaderFactory()
-            .setReferenceSequence(TestResourcesUtils.getWalkthroughDataFile("2L.fragment.fa"));
+            .setReferenceSequence(TestResourcesUtils.getWalkthroughDataFile("2L.fragment.fa").toPath());
 
     // empty header for Walkthrough data - we do not expect headers to contain more information
     private final static SAMFileHeader EMPTY_HEADER = new SAMFileHeader();

--- a/src/test/java/org/magicdgs/readtools/utils/read/ReadWriterFactoryUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/ReadWriterFactoryUnitTest.java
@@ -94,7 +94,7 @@ public class ReadWriterFactoryUnitTest extends RTBaseTest {
     @Test(expectedExceptions = UserException.CouldNotCreateOutputFile.class)
     public void testCramFailingWithNonExistingReference() {
         new ReadWriterFactory()
-                .setReferenceFile(new File("notExisting.fasta"))
+                .setReferencePath(new File("notExisting.fasta").toPath())
                 .createWriter(new File(testDir, "example.cram").getAbsolutePath(),
                         new SAMFileHeader(), true);
     }

--- a/src/test/java/org/magicdgs/readtools/utils/read/ReadWriterFactoryUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/ReadWriterFactoryUnitTest.java
@@ -115,8 +115,8 @@ public class ReadWriterFactoryUnitTest extends RTBaseTest {
                             + "/2L.fragment.fa");
             Files.copy(localRef, hdfsRef);
 
-            // TODO - this is failing temporarily because the reference is in HDFS
-            // TODO - but it should not be a problem
+            // TODO - this should fail temporarily due to https://github.com/magicDGS/ReadTools/issues/376
+            // TODO - after addressing, it should not thrown any exception
             Assert.assertThrows(UserException.MissingReference.class, () ->
                     new ReadWriterFactory().setReferencePath(hdfsRef)
                             .createWriter(new File(testDir, "hdfs.example.cram").getAbsolutePath(),


### PR DESCRIPTION
This PR adds support for `java.nio.Path` reference in `DistmapPartDownloader` and `ReadReaderFactory` (which is supposed to be used in every tool/engine except the distmap downloader).

The support implemented here is only for reading, not for writing; nevertheless, the interfaces for writing were changed to take a `Path` instead to consistently handling the input.

**WARNING: `java.nio.Path` in writers is unsupported due to HTSJDK limitations. This may change in the future.**

Closes https://github.com/magicDGS/ReadTools/issues/288