### PR TITLE
Upgrade GATK to 4.beta.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ repositories {
     }
 }
 // versions for the dependencies to resolve conflicts
-final gatkVersion = '4.beta.5-55-g577c763-SNAPSHOT'
+final gatkVersion = '4.beta.6-SNAPSHOT'
 final htsjdkVersion = '2.12.0'
 final testNGVersion = '6.11'
 final mockitoVersion = '2.7.19'

--- a/src/main/java/org/magicdgs/readtools/tools/barcodes/dictionary/BarcodeDictionaryFactory.java
+++ b/src/main/java/org/magicdgs/readtools/tools/barcodes/dictionary/BarcodeDictionaryFactory.java
@@ -33,8 +33,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.barclay.utils.Utils;
 import org.broadinstitute.hellbender.exceptions.UserException;
-import org.broadinstitute.hellbender.utils.text.parsers.TabbedInputParser;
-import org.broadinstitute.hellbender.utils.text.parsers.TabbedTextFileWithHeaderParser;
+import picard.util.TabbedInputParser;
+import picard.util.TabbedTextFileWithHeaderParser;
 import scala.Tuple3;
 
 import java.io.IOException;


### PR DESCRIPTION
Upgrading to GATK 4.0.0.0 is not possible yet, because there are some incompatibilities with respect to the arguments that are in use (concretely, regarding ReadFilters and CommandLineProgram).

Thus, this is a minor update with almost no chages, which will help to keep some important changes without breaking compatibility.

Closes #369
Part of #372 