### PR TITLE
Upgrade GATK to 4.beta.6-45-g424bd95 (SNAPSHOT)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ repositories {
     }
 }
 // versions for the dependencies to resolve conflicts
-final gatkVersion = '4.beta.6-SNAPSHOT'
+final gatkVersion = '4.beta.6-45-g424bd95-SNAPSHOT'
 final htsjdkVersion = '2.12.0'
 final testNGVersion = '6.11'
 final mockitoVersion = '2.7.19'


### PR DESCRIPTION
Another minor bump of GATK with no downstream effect.

Should check locally:

- [x] Test pass
- [x] Intact command line (or minor changes)