### PR TITLE
Upgrade GATK to 4.beta.6-87-g13bb6e0 SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,8 +49,8 @@ repositories {
     }
 }
 // versions for the dependencies to resolve conflicts
-final gatkVersion = '4.beta.6-45-g424bd95-SNAPSHOT'
-final htsjdkVersion = '2.12.0'
+final gatkVersion = '4.beta.6-83-g5f96033-SNAPSHOT'
+final htsjdkVersion = '2.13.1'
 final testNGVersion = '6.11'
 final mockitoVersion = '2.7.19'
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ repositories {
     }
 }
 // versions for the dependencies to resolve conflicts
-final gatkVersion = '4.beta.6-83-g5f96033-SNAPSHOT'
+final gatkVersion = '4.beta.6-87-g13bb6e0-SNAPSHOT'
 final htsjdkVersion = '2.13.1'
 final testNGVersion = '6.11'
 final mockitoVersion = '2.7.19'


### PR DESCRIPTION
Last possible upgrade of GATK dependency without a breaking change in the command line due to the `ReadFilters` (see #372). Includes two updates in the list of small changes in that PR:

1. Upgrade to 4.beta.6-83-g5f96033 SNAPSHOT
  - [x] Test passing
  - [x] Command line intact (although expansion of argument list changed, but not documented before)
  - [x] Documentation checked (equal or improved)
  - [x] In addition, there is no more warnings while running docgen (closes #350)
  - [x] Includes update of HTSJDK to 2.13.1 as a side effect
  - [x] Added functionality of several libraries in `LibraryReadFilter`
2. Upgrade to 4.beta.6-87-g13bb6e0-SNAPSHOT
  - [x] Test passing
  - [x] Command line intact
  - [x] Documentation checked (equal or improved)
