### PR TITLE
Fix argument documentation breaking table if comming from javadoc

### DIFF
--- a/src/main/resources/org/magicdgs/readtools/documentation/generic.template.md
+++ b/src/main/resources/org/magicdgs/readtools/documentation/generic.template.md
@@ -4,7 +4,7 @@ TODO: it requires a new version of FreeMarker for accessing some mehtods
 <#if arg.minValue?is_number || arg.maxValue?is_number><#if arg.minValue != "-INF" && arg.maxValue != "INF"><br/>[${arg.minValue}, ${arg.maxValue}]</#if></#if>
 -->
 <#macro argtype arg>${arg.type}</#macro>
-<#macro argdesc arg><#if arg.fulltext != "">${arg.fulltext}<#else>${arg.summary}</#if><#if arg.options?size != 0><br/><br/><@argoptions arg=arg/></#if></#macro>
+<#macro argdesc arg><#if arg.fulltext != ""><@compress single_line=true>${arg.fulltext}</@compress><#else>${arg.summary}</#if><#if arg.options?size != 0><br/><br/><@argoptions arg=arg/></#if></#macro>
 <#macro argoptions arg><b>Possible values:</b> <#list arg.options as opt><i>${opt.name}</i><#if opt.summary != ""> (${opt.summary})</#if><#if opt_has_next>, </#if></#list></#macro>
 <#macro argumentlist name myargs show_default=true>
     <#if myargs?size != 0>


### PR DESCRIPTION
Change in the FreeMarker template to use the `fulltext` properly in macro for argument description. Using the `@compress single_line=true` macro will remove the end of line for the fulltext, which is populated from the javadoc creating incompatibilities with the table generated by jekyll.

Closes #377 and possibly future problems with javadoc-populated documentation.