### PR TITLE
Add downloads information to README and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Language](http://img.shields.io/badge/language-java-brightgreen.svg)](https://www.java.com/)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/dd842750e7a74112870a5156a24a8cbf)](https://www.codacy.com/app/daniel-gomez-sanchez/ReadTools?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=magicDGS/ReadTools&amp;utm_campaign=Badge_Grade)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Github Releases](https://img.shields.io/github/release/magicDGS/ReadTools.svg?logo=github)](https://github.com/magicDGS/ReadTools/releases/latest)
+[![Github Releases](https://img.shields.io/github/downloads/atom/atom/total.svg?logo=github)](http://www.somsubhra.com/github-release-stats/?username=magicDGS&repository=ReadTools)
 
 # _ReadTools_: a universal toolkit for handling sequence data from different sequencing platforms
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,8 +12,10 @@ _ReadTools_ provides a consistent and highly tested set of tools for processing 
 Diverse formats were developed for storing reads (see [Read sources](read_sources.html)), but _ReadTools_ opt for following the [SAM specs]({{site.data.formats.specs.sam}}) to maintain a common data format to store both raw/mapped reads. Thus, _ReadTools_ also helps to standardize sequencing data in different formats.
 
 ## Download
+[![Github Releases](https://img.shields.io/github/downloads/atom/atom/total.svg?logo=github)](http://www.somsubhra.com/github-release-stats/?username=magicDGS&repository=ReadTools)
 
-Executable jar files for all released versions can be found under [Releases]. For using unreleased versions, see the [README]({{site.data.repo.readme}}).
+Download the latest executable jar from the top of the page. Previous versions can be retrieved from the [GitHub Releases page]({{site.data.repo.releases}}).
+If you would like to use an unreleased version, see the [README]({{site.data.repo.readme}}).
 
 Both released and unreleased changes are reported in the [CHANGELOG]({{site.data.repo.changelog}}).
 


### PR DESCRIPTION
* Version and total downloads badges to README
* Total downloads badge to documentation index
* Improve "Download" section of documentation index
* In the downloads badge, link to statistics of release downloads