### PR TITLE
Fix license in MANIFEST failing in OSX

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 import javax.tools.ToolProvider
 import java.nio.file.Files
+import com.github.jengelman.gradle.plugins.shadow.transformers.ApacheLicenseResourceTransformer
 
 // Dependencies for the buildscript (not the program)
 buildscript {
@@ -190,6 +191,7 @@ task currentJar(type: Copy){
 
 shadowJar {
     zip64 true
+    transform(ApacheLicenseResourceTransformer)
     mergeServiceFiles()
     finalizedBy currentJar
 }


### PR DESCRIPTION
In MacOS, files and folders cannot have the same name and because the
File System is case-sensitive, uncompressing the packaged jar fails due
to a collision in names between the LICENSE file and the license/
folder.

This commit fixes the error by using the license transformer from the
gradle shadow plugin (ApacheLicenseResourceTransformer).