### PR TITLE
Add validation stringency to QualityEncodingDetector

### DIFF
--- a/src/main/java/org/magicdgs/readtools/cmd/RTStandardArguments.java
+++ b/src/main/java/org/magicdgs/readtools/cmd/RTStandardArguments.java
@@ -68,6 +68,9 @@ public class RTStandardArguments {
 
     public static final String READ_VALIDATION_STRINGENCY_LONG_NAME = "readValidationStringency";
     public static final String READ_VALIDATION_STRINGENCY_SHORT_NAME = "VS";
+    public static final String READ_VALIDATION_STRINGENCY_DOC = "Validation stringency for all SAM/BAM/CRAM files read by this program. "
+            + "The default stringency value SILENT can improve performance when processing "
+            + "a BAM file in which variable-length data (read, qualities, tags) do not otherwise need to be decoded.";
 
     // TODO - the long name was not in StandardArgumentDefinitions
     // TODO - and the short one wil be removed in https://github.com/broadinstitute/gatk/pull/4232

--- a/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTInputArgumentCollection.java
+++ b/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTInputArgumentCollection.java
@@ -46,11 +46,8 @@ import java.nio.file.Path;
 public final class RTInputArgumentCollection implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    // TODO: change our default validation stringency?
     @Argument(fullName = RTStandardArguments.READ_VALIDATION_STRINGENCY_LONG_NAME, shortName = RTStandardArguments.READ_VALIDATION_STRINGENCY_SHORT_NAME,
-            doc = "Validation stringency for all SAM/BAM/CRAM files read by this program. "
-                    + "The default stringency value SILENT can improve performance when processing "
-                    + "a BAM file in which variable-length data (read, qualities, tags) do not otherwise need to be decoded.",
+            doc = RTStandardArguments.READ_VALIDATION_STRINGENCY_DOC,
             common = true, optional = true)
     public ValidationStringency readValidationStringency =
             ReadConstants.DEFAULT_READ_VALIDATION_STRINGENCY;

--- a/src/main/java/org/magicdgs/readtools/tools/distmap/DistmapPartDownloader.java
+++ b/src/main/java/org/magicdgs/readtools/tools/distmap/DistmapPartDownloader.java
@@ -97,9 +97,7 @@ final class DistmapPartDownloader {
     private boolean noRemoveTaskProgramGroup = false;
 
     @Argument(fullName = RTStandardArguments.READ_VALIDATION_STRINGENCY_LONG_NAME, shortName = RTStandardArguments.READ_VALIDATION_STRINGENCY_SHORT_NAME,
-            doc = "Validation stringency for all SAM/BAM/CRAM files read by this program. "
-                    + "The default stringency value SILENT can improve performance when processing "
-                    + "a BAM file in which variable-length data (read, qualities, tags) do not otherwise need to be decoded.",
+            doc = RTStandardArguments.READ_VALIDATION_STRINGENCY_DOC,
             common = true, optional = true)
     private ValidationStringency readValidationStringency =
             ReadConstants.DEFAULT_READ_VALIDATION_STRINGENCY;

--- a/src/main/java/org/magicdgs/readtools/tools/quality/QualityEncodingDetector.java
+++ b/src/main/java/org/magicdgs/readtools/tools/quality/QualityEncodingDetector.java
@@ -30,11 +30,13 @@ import org.magicdgs.readtools.engine.ReadToolsProgram;
 import org.magicdgs.readtools.engine.sourcehandler.ReadsSourceHandler;
 import org.magicdgs.readtools.utils.read.ReadReaderFactory;
 
+import htsjdk.samtools.ValidationStringency;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.programgroups.DiagnosticsAndQCProgramGroup;
+import org.broadinstitute.hellbender.utils.read.ReadConstants;
 
 import java.io.IOException;
 
@@ -53,6 +55,12 @@ public final class QualityEncodingDetector extends ReadToolsProgram {
     @Argument(fullName = "maximumReads", shortName = "maximumReads", doc = "Maximum number of reads to use for detect the quality encoding.", optional = true)
     public Long recordsToIterate = RTDefaults.MAX_RECORDS_FOR_QUALITY;
 
+    @Argument(fullName = RTStandardArguments.READ_VALIDATION_STRINGENCY_LONG_NAME, shortName = RTStandardArguments.READ_VALIDATION_STRINGENCY_SHORT_NAME,
+            doc = RTStandardArguments.READ_VALIDATION_STRINGENCY_DOC,
+            common = true, optional = true)
+    public ValidationStringency readValidationStringency =
+            ReadConstants.DEFAULT_READ_VALIDATION_STRINGENCY;
+
     @Override
     protected String[] customCommandLineValidation() {
         if (recordsToIterate <= 0) {
@@ -64,7 +72,7 @@ public final class QualityEncodingDetector extends ReadToolsProgram {
 
     @Override
     protected Object doWork() {
-        try (final ReadsSourceHandler handler = ReadsSourceHandler.getHandler(sourceString, new ReadReaderFactory())) {
+        try (final ReadsSourceHandler handler = ReadsSourceHandler.getHandler(sourceString, new ReadReaderFactory().setValidationStringency(readValidationStringency))) {
             return handler.getQualityEncoding(recordsToIterate);
         } catch (IOException e) {
             logger.debug(e);


### PR DESCRIPTION
In addition, this commit extracts the doc String into a constant for consistency between tools.

Closes #417