### PR TITLE
Share documentation String for --forceOverwrite

### DIFF
--- a/src/main/java/org/magicdgs/readtools/cmd/RTStandardArguments.java
+++ b/src/main/java/org/magicdgs/readtools/cmd/RTStandardArguments.java
@@ -126,6 +126,7 @@ public class RTStandardArguments {
 
     /** Output for force overwrite in the tools. */
     public static final String FORCE_OVERWRITE_NAME = "forceOverwrite";
+    public static final String FORCE_OVERWRITE_DOC = "Force output overwriting if it exists";
 
     /** Output format of the tool. */
     public static final String OUTPUT_FORMAT_NAME = "outputFormat";

--- a/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputArgumentCollection.java
+++ b/src/main/java/org/magicdgs/readtools/cmd/argumentcollections/RTOutputArgumentCollection.java
@@ -49,7 +49,7 @@ public abstract class RTOutputArgumentCollection implements Serializable {
 
     protected final static Logger logger = LogManager.getLogger(RTOutputArgumentCollection.class);
 
-    @Argument(fullName = RTStandardArguments.FORCE_OVERWRITE_NAME, shortName = RTStandardArguments.FORCE_OVERWRITE_NAME, doc = "Force output overwriting if it exists", optional = true, common = true)
+    @Argument(fullName = RTStandardArguments.FORCE_OVERWRITE_NAME, shortName = RTStandardArguments.FORCE_OVERWRITE_NAME, doc = RTStandardArguments.FORCE_OVERWRITE_DOC, optional = true, common = true)
     public Boolean forceOverwrite = false;
 
     /**

--- a/src/main/java/org/magicdgs/readtools/tools/distmap/ReadsToDistmap.java
+++ b/src/main/java/org/magicdgs/readtools/tools/distmap/ReadsToDistmap.java
@@ -77,7 +77,7 @@ public final class ReadsToDistmap extends ReadToolsWalker {
             + "Find more information about this tool in "
             + RTHelpConstants.DOCUMENTATION_PAGE + "ReadsToDistmap.html";
 
-    @Argument(fullName = RTStandardArguments.FORCE_OVERWRITE_NAME, shortName = RTStandardArguments.FORCE_OVERWRITE_NAME, doc = "Force output overwriting if it exists", common = true, optional = true)
+    @Argument(fullName = RTStandardArguments.FORCE_OVERWRITE_NAME, shortName = RTStandardArguments.FORCE_OVERWRITE_NAME, doc = RTStandardArguments.FORCE_OVERWRITE_DOC, common = true, optional = true)
     public Boolean forceOverwrite = false;
 
     @Argument(fullName = RTStandardArguments.OUTPUT_LONG_NAME, shortName = RTStandardArguments.OUTPUT_SHORT_NAME, doc = "Output in Distmap format. Expected to be in an HDFS file system.", optional = false)


### PR DESCRIPTION
There are already two tools that share this argument with the same documentation String and there will be more in the near future. This allows to maintain consisten the documentation with minimal efford for this widely-used argument.