### PR TITLE
Support java.nio.Path with FASTQ input files

### DIFF
--- a/src/main/java/org/magicdgs/readtools/utils/read/ReadReaderFactory.java
+++ b/src/main/java/org/magicdgs/readtools/utils/read/ReadReaderFactory.java
@@ -31,6 +31,7 @@ import htsjdk.samtools.ValidationStringency;
 import htsjdk.samtools.cram.ref.CRAMReferenceSource;
 import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.fastq.FastqReader;
+import htsjdk.samtools.util.IOUtil;
 import org.broadinstitute.hellbender.exceptions.UserException;
 
 import java.io.File;
@@ -85,25 +86,9 @@ public class ReadReaderFactory {
         return openWrappingException(() -> samFactory.open(path), path::toString);
     }
 
-    /** Open a new SAMReader from a file. */
-    public SamReader openSamReader(final File file) {
-        return openWrappingException(() -> samFactory.open(file), file::getAbsolutePath);
-    }
-
-    /** Open a new SAMReader from a resource. */
-    public SamReader openSamReader(final SamInputResource resource) {
-        // TODO: probably this should disappear in favour of a String open.
-        return openWrappingException(() -> samFactory.open(resource), resource::toString);
-    }
-
     /** Open a new FastqReader from a path. */
     public FastqReader openFastqReader(final Path path) {
-        return openFastqReader(path.toFile());
-    }
-
-    /** Open a new FastqReaderr from a file. */
-    public FastqReader openFastqReader(final File file) {
-        return openWrappingException(() -> new FastqReader(file), file::getAbsolutePath);
+        return openWrappingException(() -> new FastqReader(IOUtil.openFileForBufferedReading(path)), () -> path.toUri().toString());
     }
 
     // any exception caused by open a file will thrown a could not read input file exception

--- a/src/test/java/org/magicdgs/readtools/engine/sourcehandler/ReadsSourceHandlerUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/engine/sourcehandler/ReadsSourceHandlerUnitTest.java
@@ -243,7 +243,7 @@ public class ReadsSourceHandlerUnitTest extends RTBaseTest {
     }
 
     private final SAMFileHeader getHeaderForFile(final File file) {
-        try (final SamReader reader = FACTORY_FOR_TEST.openSamReader(file)) {
+        try (final SamReader reader = FACTORY_FOR_TEST.openSamReader(file.toPath())) {
             return reader.getFileHeader();
         } catch (IOException e) {
             // do nothing

--- a/src/test/java/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcodeIntegrationTest.java
+++ b/src/test/java/org/magicdgs/readtools/tools/barcodes/AssignReadGroupByBarcodeIntegrationTest.java
@@ -236,8 +236,8 @@ public class AssignReadGroupByBarcodeIntegrationTest extends RTCommandLineProgra
     private void testSamFileEquivalentForBarcodeDetection(final File actualSam, File expectedSam)
             throws Exception {
         final ReadReaderFactory factory = new ReadReaderFactory();
-        try (final SamReader actualReader = factory.openSamReader(actualSam);
-                final SamReader expectedReader = factory.openSamReader(expectedSam)) {
+        try (final SamReader actualReader = factory.openSamReader(actualSam.toPath());
+                final SamReader expectedReader = factory.openSamReader(expectedSam.toPath())) {
             final SAMFileHeader actualHeader = actualReader.getFileHeader();
             final SAMFileHeader expectedHeader = expectedReader.getFileHeader();
             // check headers are equal

--- a/src/test/java/org/magicdgs/readtools/utils/read/writer/SplitGATKWriterUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/writer/SplitGATKWriterUnitTest.java
@@ -180,7 +180,7 @@ public class SplitGATKWriterUnitTest extends RTBaseTest {
         Assert.assertTrue(multipleFile.exists());
 
         // test the multiple
-        try (final SamReader reader = new ReadReaderFactory().openSamReader(multipleFile)) {
+        try (final SamReader reader = new ReadReaderFactory().openSamReader(multipleFile.toPath())) {
             Assert.assertEquals(reader.getFileHeader(), header);
             final Iterator<SAMRecord> it = reader.iterator();
             multipleReads.forEach(r -> Assert.assertEquals(it.next(), r.convertToSAMRecord(header)));


### PR DESCRIPTION
Previously our `ReadReaderFactory` was calling `Path.toFile` for FASTQ input, which might file for non-local files. This commit fix this bug and also removes non-Path methods in `ReadReaderFactory` for simplify codepaths.

Fixes #472 