### PR TITLE
Upgrade GATK to 4.0.6.0 and htsjdk to 2.16.0 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,8 +51,8 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 // versions for the dependencies to resolve conflicts
-final gatkVersion = '4.0.2.1'
-final htsjdkVersion = '2.15.0'
+final gatkVersion = '4.0.6.0'
+final htsjdkVersion = '2.16.0'
 final testNGVersion = '6.11'
 final mockitoVersion = '2.7.19'
 

--- a/src/main/java/org/magicdgs/readtools/Main.java
+++ b/src/main/java/org/magicdgs/readtools/Main.java
@@ -144,4 +144,16 @@ public final class Main extends org.broadinstitute.hellbender.Main {
         }
     }
 
+    /**
+     * Get deprecation message for a tool.
+     *
+     * @param toolName command specified by the user
+     * @return deprecation message string, or null if none
+     */
+    @Override
+    public String getToolDeprecationMessage(final String toolName) {
+        // TODO: implement deprecation registry for pre-release tools
+        // TODO: https://github.com/magicDGS/ReadTools/issues/488
+        return null;
+    }
 }

--- a/src/main/java/org/magicdgs/readtools/utils/read/ReadWriterFactory.java
+++ b/src/main/java/org/magicdgs/readtools/utils/read/ReadWriterFactory.java
@@ -157,7 +157,6 @@ public final class ReadWriterFactory {
     /** Sets the reference file. This is required for CRAM writers. */
     public ReadWriterFactory setReferencePath(final Path referencePath) {
         logger.debug("Reference file for FASTQ/Distmap writers is ignored");
-        // TODO - this should set the reference Path in the samFactory (https://github.com/magicDGS/ReadTools/issues/376)
         this.referencePath = referencePath;
         return this;
     }

--- a/src/test/java/org/magicdgs/readtools/engine/RTDataSourceUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/engine/RTDataSourceUnitTest.java
@@ -33,7 +33,6 @@ import htsjdk.samtools.SAMTextHeaderCodec;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.util.BufferedLineReader;
 import htsjdk.samtools.util.FastqQualityFormat;
-import htsjdk.samtools.util.StringLineReader;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.read.GATKRead;

--- a/src/test/java/org/magicdgs/readtools/utils/read/ReadWriterFactoryUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/ReadWriterFactoryUnitTest.java
@@ -31,6 +31,7 @@ import org.magicdgs.readtools.utils.read.writer.NullGATKWriter;
 import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
@@ -115,14 +116,16 @@ public class ReadWriterFactoryUnitTest extends RTBaseTest {
                             + "/2L.fragment.fa");
             Files.copy(localRef, hdfsRef);
 
-            // TODO - this should fail temporarily due to https://github.com/magicDGS/ReadTools/issues/376
-            // TODO - after addressing, it should not thrown any exception
-            Assert.assertThrows(UserException.MissingReference.class, () ->
-                    new ReadWriterFactory().setReferencePath(hdfsRef)
-                            .createWriter(new File(testDir, "hdfs.example.cram").getAbsolutePath(),
-                                    new SAMFileHeader(), true)
-            );
+            // create a writer should not fail
+            final File output = new File(testDir, "hdfs.example.cram");
+            final GATKReadWriter writer = new ReadWriterFactory().setReferencePath(hdfsRef)
+                            .createWriter(output.getAbsolutePath(),
+                                    new SAMFileHeader(), true);
+            // neither closing it
+            writer.close();
 
+            // and the file should exists (with no reads)
+            Assert.assertTrue(output.exists());
         } finally {
             // always stop the mini-cluster
             MiniClusterUtils.stopCluster(cluster);

--- a/src/test/java/org/magicdgs/readtools/utils/read/ReadWriterFactoryUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/read/ReadWriterFactoryUnitTest.java
@@ -31,7 +31,6 @@ import org.magicdgs.readtools.utils.read.writer.NullGATKWriter;
 import org.magicdgs.readtools.RTBaseTest;
 
 import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.SAMFileWriter;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.io.IOUtils;


### PR DESCRIPTION
Includes:

- Update htsjdk to 2.16.0 (closes #479)
- Fix deprecation
- Change code to support CRAM reference files on non-local filesystems (closes #316 / closes #376)
