### PR TITLE
Allow Casava formatted read names with barcode separators

### DIFF
--- a/src/main/java/org/magicdgs/readtools/utils/fastq/FastqReadNameEncoding.java
+++ b/src/main/java/org/magicdgs/readtools/utils/fastq/FastqReadNameEncoding.java
@@ -55,8 +55,8 @@ public enum FastqReadNameEncoding {
     // second group = ([012])    -> the pair-information ('1', '2', or '0')
     // third group  = ([YN])     -> PF flag (vendors quality)
     // no group     = [0-9]+     -> numeric value that does not contain important information in our framework
-    // fourth group = ([ATCGN]+) -> the barcode information (restricted to nucleotides)
-    CASAVA("([\\S]+)\\s+([012]):([YN]):[0-9]+:([ATCGN]+).?", 2, 4, 3),
+    // fourth group = ([^\\s]+) -> the barcode information (restricted to any character except space to allow barcode separators)
+    CASAVA("([\\S]+)\\s+([012]):([YN]):[0-9]+:([^\\s]+).?", 2, 4, 3),
     // this ILLUMINA pattern match with/without barcodes
     // first group  = ([^#/]+)                 -> any character that is not the marker of barcode or pair-info separator
     // second group = (#([^/\\s]+))?           -> one or none of # followed by something that is not a / or white space

--- a/src/test/java/org/magicdgs/readtools/utils/fastq/FastqReadNameEncodingUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/fastq/FastqReadNameEncodingUnitTest.java
@@ -134,6 +134,16 @@ public class FastqReadNameEncodingUnitTest extends RTBaseTest {
                         // barcode combined into one - could be modified by the java property
                         new String[]{"CCCCCCCC+CCCCCCCC"}
                 },
+                // previous Casava formatting but with hyphen as barcode separator (default)
+                {FastqReadNameEncoding.CASAVA,
+                        "@E00514:354:HLH2VCCXY:4:1101:21968:1784 2:N:0:CCCCCCCC-CCCCCCCC",
+                        // expected name without space
+                        "@E00514:354:HLH2VCCXY:4:1101:21968:1784",
+                        // second (false/true) and do not pass control (false)
+                        false, true, false,
+                        // barcode combined into one - could be modified by the java property
+                        new String[]{"CCCCCCCC", "CCCCCCCC"}
+                },
                 // Nanopore name format - see https://github.com/nanopore-wgs-consortium/NA12878
                 {FastqReadNameEncoding.ILLUMINA,
                         "@455ce49b-a59e-4c03-8639-5be6272eb928_Basecall_Alignment_template MinION2_20160716_FNFAB23716_MN16454_sequencing_run_Chip86_Human_Genomic_1D_Rapid_Tuned3_99286_ch190_read287_strand1",

--- a/src/test/java/org/magicdgs/readtools/utils/fastq/FastqReadNameEncodingUnitTest.java
+++ b/src/test/java/org/magicdgs/readtools/utils/fastq/FastqReadNameEncodingUnitTest.java
@@ -109,6 +109,31 @@ public class FastqReadNameEncodingUnitTest extends RTBaseTest {
                         "@ST-E00169:175:HMTL3CCXX:7:1101:3457:1573 2:Y:0:NTGATTAC",
                         "@ST-E00169:175:HMTL3CCXX:7:1101:3457:1573", false, true, true,
                         new String[] {"NTGATTAC"}},
+                // casava with numbers instead of barcodes
+                {FastqReadNameEncoding.CASAVA,
+                        "@EAS139:136:FC706VJ:2:2104:15343:197393 1:N:18:1",
+                        "@EAS139:136:FC706VJ:2:2104:15343:197393", true, false, false,
+                        new String[] {"1"}},
+                // first of pair Casava format dual indexing with + separator (found in at least one provider)
+                {FastqReadNameEncoding.CASAVA,
+                        "@E00514:354:HLH2VCCXY:4:1101:21968:1784 1:N:0:CCCCCCCC+CCCCCCCC",
+                        // expected name without space
+                        "@E00514:354:HLH2VCCXY:4:1101:21968:1784",
+                        // first (true/false) and do not pass control (false)
+                        true, false, false,
+                        // barcode combined into one - could be modified by the java property
+                        new String[]{"CCCCCCCC+CCCCCCCC"}
+                },
+                // second of pair Casava format dual indexing with + separator (found in at least one provider)
+                {FastqReadNameEncoding.CASAVA,
+                        "@E00514:354:HLH2VCCXY:4:1101:21968:1784 2:N:0:CCCCCCCC+CCCCCCCC",
+                        // expected name without space
+                        "@E00514:354:HLH2VCCXY:4:1101:21968:1784",
+                        // second (false/true) and do not pass control (false)
+                        false, true, false,
+                        // barcode combined into one - could be modified by the java property
+                        new String[]{"CCCCCCCC+CCCCCCCC"}
+                },
                 // Nanopore name format - see https://github.com/nanopore-wgs-consortium/NA12878
                 {FastqReadNameEncoding.ILLUMINA,
                         "@455ce49b-a59e-4c03-8639-5be6272eb928_Basecall_Alignment_template MinION2_20160716_FNFAB23716_MN16454_sequencing_run_Chip86_Human_Genomic_1D_Rapid_Tuned3_99286_ch190_read287_strand1",


### PR DESCRIPTION
As discussed in #512 