### PR TITLE
Use quoted split pattern for barcodes

### DIFF
--- a/src/main/java/org/magicdgs/readtools/RTHelpConstants.java
+++ b/src/main/java/org/magicdgs/readtools/RTHelpConstants.java
@@ -189,9 +189,13 @@ public final class RTHelpConstants {
         logger.info("Barcode sequence ({}) separator: '{}'",
                 () -> RTReadUtils.RAW_BARCODE_TAG,
                 () -> RTDefaults.BARCODE_INDEX_DELIMITER);
+        logger.debug("Barcode sequence split pattern: '{}'",
+                RTReadUtils.DEFAULT_BARCODE_INDEX_SPLIT);
         logger.info("Barcode quality ({}) separator: '{}'",
                 () -> RTReadUtils.RAW_BARCODE_QUALITY_TAG,
                 () -> RTDefaults.BARCODE_QUALITY_DELIMITER);
+        logger.debug("Barcode quality split pattern: '{}'",
+                RTReadUtils.DEFAULT_BARCODE_QUALITY_SPLIT);
         logger.info("Number of records to detect quality: {}",
                 () -> RTDefaults.MAX_RECORDS_FOR_QUALITY);
         // for debugging

--- a/src/main/java/org/magicdgs/readtools/utils/fastq/FastqReadNameEncoding.java
+++ b/src/main/java/org/magicdgs/readtools/utils/fastq/FastqReadNameEncoding.java
@@ -169,7 +169,7 @@ public enum FastqReadNameEncoding {
     }
 
     /**
-     * Returns the barcodes in the read name (splitted by {@link RTDefaults#BARCODE_INDEX_DELIMITER}).
+     * Returns the barcodes in the read name (splitted by {@link RTReadUtils#DEFAULT_BARCODE_INDEX_SPLIT}).
      *
      * @param readName the read name to extract the information.
      *
@@ -181,7 +181,7 @@ public enum FastqReadNameEncoding {
             if (matcher.find()) {
                 final String barcode = matcher.group(barcodeGroup);
                 if (barcode != null) {
-                    return barcode.split(RTDefaults.BARCODE_INDEX_DELIMITER);
+                    return RTReadUtils.DEFAULT_BARCODE_INDEX_SPLIT.split(barcode);
                 }
             }
         }


### PR DESCRIPTION
This commit separates the pattern for split barcodes sequences/qualities from the default `String` for the separator by quoting the java property (or default) argument. This have several advantages:

- Split will not fail after providing an special character (e.g., +)
- Combined barcodes will have the same separator as the one in `RTDefaults`
- Java property is not required to be a regexp
- Pre-compiled patterns might be faster (untested)

Closes #525 